### PR TITLE
Hacky fix for MacOS build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
     }
 
     buildGameLib(b, build_options, target, optimize, test_step, internal, tracy_enabled);
-    checkGameLibStep(b, build_options, target, optimize, internal, tracy_enabled);
+    // checkGameLibStep(b, build_options, target, optimize, internal, tracy_enabled);
 
     generateImGuiBindingsStep(b, target, optimize);
 }
@@ -62,7 +62,7 @@ fn buildExecutable(
     run_step.dependOn(&run_cmd.step);
 
     const exe_tests = b.addTest(.{ .root_module = module });
-    linkExeOnlyLibraries(b, exe_tests, target, optimize);
+    // linkExeOnlyLibraries(b, exe_tests, target, optimize);
     const run_exe_tests = b.addRunArtifact(exe_tests);
     test_step.dependOn(&run_exe_tests.step);
 }
@@ -83,8 +83,8 @@ fn buildGameLib(
     }
 
     const lib_tests = b.addTest(.{ .root_module = lib.root_module });
-    linkGameLibraries(b, lib_tests, target, optimize, internal);
-    linkTracy(b, lib_tests, target, optimize, tracy_enabled);
+    // linkGameLibraries(b, lib_tests, target, optimize, internal);
+    // linkTracy(b, lib_tests, target, optimize, tracy_enabled);
     const run_lib_tests = b.addRunArtifact(lib_tests);
     test_step.dependOn(&run_lib_tests.step);
 }


### PR DESCRIPTION
Hi @zoeesilcock, I love your project. I am on a Macbook and have encountered an error trying to build the project. With some digging I found out that you seem to link the binary against `libplayground.dylib` twice:
```
gamedev-playground % otool -L zig-out/bin/gamedev-playground
zig-out/bin/gamedev-playground:
	@rpath/libSDL3.dylib (compatibility version 1.0.0, current version 0.2.14)
	@rpath/libSDL3.dylib (compatibility version 1.0.0, current version 0.2.14)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```

You are also linking `libplayground.dylib` against SDL twice:
```
gamedev-playground % otool -L zig-out/lib/libplayground.dylib
zig-out/lib/libplayground.dylib:
	@rpath/libplayground.dylib (compatibility version 1.0.0, current version 1.0.0)
	@rpath/libSDL3.dylib (compatibility version 1.0.0, current version 0.2.14)
	@rpath/libSDL3.dylib (compatibility version 1.0.0, current version 0.2.14)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```

On MacOS, that's a fatal error which causes a crash.
Aparrently, on Windows and Linux links are deduplicated automatically, which is probably why you haven't had a problem in that respect.

I managed to get it to build, albeit not with a clean fix. I am only getting started learning zig and its build system, so I haven't managed to fix it cleanly, yet. Maybe you can use my fix as a starting point to work out a better solution. I'd be more than happy to help with testing on MacOS, if you're interested.

Cheers!