### PR TITLE
Update to zig version 0.15.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v2
         with:
-            version: 0.14.1
+            version: 0.15.1
       - run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -177,10 +177,13 @@ fn createImGuiLib(
         .optimize = optimize,
         .preferred_link_mode = .dynamic,
     })) |sdl_dep| {
-        const dcimgui_sdl = b.addStaticLibrary(.{
-            .name = "dcimgui_sdl",
+        const module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+        });
+        const dcimgui_sdl = b.addLibrary(.{
+            .name = "dcimgui_sdl",
+            .root_module = module,
         });
 
         dcimgui_sdl.root_module.link_libcpp = true;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x4d0121353119f6fd,
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/castholm/SDL.git#1994ca5dbad5a3e3c670a9ab8533d86cfd97bdc0",
-            .hash = "sdl-0.2.6+3.2.20-7uIn9NgjfwHH5a6HhyLHat2nHU3OP5B05QHhKJKuxEex",
+            .url = "git+https://github.com/castholm/SDL.git#091d7f77f3ef68989ac15ff82d89fd7a67344c59",
+            .hash = "sdl-0.3.0+3.2.22-7uIn9Cs0fwFLMvKx33J0f7fxZ12wbbbFd9oGnqVjfWC2",
             .lazy = true,
         },
         .imgui = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .gamedev_playground,
-    .version = "0.3.0",
-    .minimum_zig_version = "0.14.1",
+    .version = "0.4.0",
+    .minimum_zig_version = "0.15.1",
     .fingerprint = 0x4d0121353119f6fd,
     .dependencies = .{
         .sdl = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x4d0121353119f6fd,
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/castholm/SDL.git#v0.2.5+3.2.18",
-            .hash = "sdl-0.2.5+3.2.18-7uIn9FwZfwHKOwSubcg5_CiW4fXag5IIsiV_jnLdkpDM",
+            .url = "git+https://github.com/castholm/SDL.git#1994ca5dbad5a3e3c670a9ab8533d86cfd97bdc0",
+            .hash = "sdl-0.2.6+3.2.20-7uIn9NgjfwHH5a6HhyLHat2nHU3OP5B05QHhKJKuxEex",
             .lazy = true,
         },
         .imgui = .{

--- a/examples/aseprite.zig
+++ b/examples/aseprite.zig
@@ -1,8 +1,5 @@
 const std = @import("std");
 
-// TODO: Remove once Zig has finished migrating to unmanaged-style containers.
-const ArrayList = std.ArrayListUnmanaged;
-
 // Public API.
 pub const AseDocument = struct {
     header: *const AseHeader,
@@ -50,7 +47,7 @@ pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator) !?AseDocumen
         var file_reader = file.reader(&buf);
 
         const opt_header: ?*AseHeader = try parseHeader(&file_reader.interface, allocator);
-        var frames: ArrayList(AseFrame) = .empty;
+        var frames: std.ArrayList(AseFrame) = .empty;
         defer frames.deinit(allocator);
 
         std.log.info("loadDocument: {s}", .{path});
@@ -67,7 +64,7 @@ pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator) !?AseDocumen
                         .{ frame_header.byte_count, frame_header.chunkCount() },
                     );
 
-                    var cel_chunks: ArrayList(*AseCelChunk) = .empty;
+                    var cel_chunks: std.ArrayList(*AseCelChunk) = .empty;
                     var opt_tags: ?[]*AseTagsChunk = null;
 
                     for (0..frame_header.chunkCount()) |_| {
@@ -407,7 +404,7 @@ fn parseCelChunk(reader: *std.Io.Reader, header: *AseChunkHeader, allocator: std
 }
 
 fn parseTagsChunks(reader: *std.Io.Reader, allocator: std.mem.Allocator) !?[]*AseTagsChunk {
-    var tag_chunks: ArrayList(*AseTagsChunk) = .empty;
+    var tag_chunks: std.ArrayList(*AseTagsChunk) = .empty;
 
     const header: AseTagsChunkHeader = .{
         .count = try reader.takeInt(u16, .little),
@@ -426,7 +423,7 @@ fn parseTagsChunks(reader: *std.Io.Reader, allocator: std.mem.Allocator) !?[]*As
         reader.toss(6 + 3 + 1);
 
         const tag_name_length = try reader.takeInt(u16, .little);
-        var buffer: ArrayList(u8) = .empty;
+        var buffer: std.ArrayList(u8) = .empty;
         for (0..tag_name_length) |_| {
             try buffer.append(allocator, try reader.takeByte());
         }

--- a/examples/cube/build.zig
+++ b/examples/cube/build.zig
@@ -26,12 +26,14 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
     module.addOptions("build_options", build_options);
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = lib_base_name,
         .root_module = module,
     });
 
-    const lib_check = b.addSharedLibrary(.{
+    const lib_check = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = lib_base_name,
         .root_module = module,
     });

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -16,9 +16,6 @@ const Y = math.Y;
 const Z = math.Z;
 const FPSState = internal.FPSState;
 
-// TODO: Remove once Zig has finished migrating to unmanaged-style containers.
-const ArrayList = std.ArrayListUnmanaged;
-
 const DebugAllocator = std.heap.DebugAllocator(.{
     .enable_memory_limit = true,
     .retain_metadata = INTERNAL,
@@ -56,7 +53,7 @@ pub const State = struct {
     delta_time_actual: u64 = 0,
 
     camera: Camera,
-    entities: ArrayList(Entity),
+    entities: std.ArrayList(Entity),
 
     pub fn deltaTime(self: *State) f32 {
         return @as(f32, @floatFromInt(self.delta_time)) / 1000;

--- a/examples/diamonds/build.zig
+++ b/examples/diamonds/build.zig
@@ -19,12 +19,14 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = lib_base_name,
         .root_module = module,
     });
 
-    const lib_check = b.addSharedLibrary(.{
+    const lib_check = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = lib_base_name,
         .root_module = module,
     });

--- a/examples/diamonds/src/debug.zig
+++ b/examples/diamonds/src/debug.zig
@@ -31,9 +31,6 @@ const G = math.G;
 const B = math.B;
 const A = math.A;
 
-// TODO: Remove once Zig has finished migrating to unmanaged-style containers.
-const ArrayList = std.ArrayListUnmanaged;
-
 const PLATFORM = @import("builtin").os.tag;
 const DOUBLE_CLICK_THRESHOLD: u64 = 300;
 const MAX_FRAME_TIME_COUNT: u32 = 300;
@@ -58,7 +55,7 @@ pub const DebugState = struct {
     show_state_inspector: bool,
 
     show_colliders: bool,
-    collisions: ArrayList(DebugCollision),
+    collisions: std.ArrayList(DebugCollision),
 
     memory_usage: [MAX_MEMORY_USAGE_COUNT]u64,
     memory_usage_current_index: u32,

--- a/examples/diamonds/src/debug.zig
+++ b/examples/diamonds/src/debug.zig
@@ -764,18 +764,24 @@ fn saveLevel(state: *State, name: []const u8) !void {
     const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
     defer file.close();
 
+    var writer_buf: [10 * 1024]u8 = undefined;
+    var file_writer = file.writer(&writer_buf);
+    var writer: *std.Io.Writer = &file_writer.interface;
+
     var walls_count: u32 = 0;
     var iter: EntityIterator = .{ .entities = &state.entities };
     while (iter.next(&.{ .block, .color, .transform })) |_| {
         walls_count += 1;
     }
-    try file.writer().writeInt(u32, walls_count, .little);
+    try writer.writeInt(u32, walls_count, .little);
 
     iter.reset();
     while (iter.next(&.{ .block, .color, .transform })) |entity| {
-        try file.writer().writeInt(u32, @intFromEnum(entity.color.?.color), .little);
-        try file.writer().writeInt(u32, @intFromEnum(entity.block.?.type), .little);
-        try file.writer().writeInt(i32, @intFromFloat(@round(entity.transform.?.position[X])), .little);
-        try file.writer().writeInt(i32, @intFromFloat(@round(entity.transform.?.position[Y])), .little);
+        try writer.writeInt(u32, @intFromEnum(entity.color.?.color), .little);
+        try writer.writeInt(u32, @intFromEnum(entity.block.?.type), .little);
+        try writer.writeInt(i32, @intFromFloat(@round(entity.transform.?.position[X])), .little);
+        try writer.writeInt(i32, @intFromFloat(@round(entity.transform.?.position[Y])), .little);
     }
+
+    try writer.flush();
 }

--- a/examples/diamonds/src/entities.zig
+++ b/examples/diamonds/src/entities.zig
@@ -11,8 +11,6 @@ const X = math.X;
 const Y = math.Y;
 const Z = math.Z;
 
-// TODO: Remove once Zig has finished migrating to unmanaged-style containers.
-const ArrayList = std.ArrayListUnmanaged;
 const PoolId = pool.PoolId;
 
 pub const EntityType = enum(u8) {
@@ -33,7 +31,7 @@ pub const EntityId = struct {
 };
 
 pub const EntityIterator = struct {
-    entities: *ArrayList(*Entity),
+    entities: *std.ArrayList(*Entity),
     index: usize = 0,
 
     pub fn next(self: *EntityIterator, comptime with_components: []const @TypeOf(.EnumLiteral)) ?*Entity {

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -40,8 +40,6 @@ const G = math.G;
 const B = math.B;
 const A = math.A;
 
-// TODO: Remove once Zig has finished migrating to unmanaged-style containers.
-const ArrayList = std.ArrayListUnmanaged;
 const DebugAllocator = std.heap.DebugAllocator(.{
     .enable_memory_limit = true,
     .retain_metadata = INTERNAL,
@@ -101,8 +99,8 @@ pub const State = struct {
     lives_remaining: u32,
 
     // Entities.
-    entities: ArrayList(*Entity),
-    entities_free: ArrayList(u32),
+    entities: std.ArrayList(*Entity),
+    entities_free: std.ArrayList(u32),
     entities_iterator: EntityIterator,
     ball_id: ?EntityId,
     current_title_id: ?EntityId,
@@ -937,7 +935,7 @@ fn loadSprite(path: []const u8, renderer: *sdl.SDL_Renderer, allocator: std.mem.
     };
 
     if (opt_doc) |doc| {
-        var textures: ArrayList(*sdl.SDL_Texture) = .empty;
+        var textures: std.ArrayList(*sdl.SDL_Texture) = .empty;
 
         for (doc.frames) |frame| {
             const surface = sdlPanicIfNull(

--- a/examples/pool.zig
+++ b/examples/pool.zig
@@ -1,8 +1,5 @@
 const std = @import("std");
 
-// TODO: Remove once Zig has finished migrating to unmanaged-style containers.
-const ArrayList = std.ArrayListUnmanaged;
-
 pub const PoolId = struct {
     index: u32,
 
@@ -21,11 +18,11 @@ pub fn Pool(comptime PooledType: type) type {
             item: PooledType,
         };
 
-        entries: ArrayList(PoolEntry),
-        entries_free: ArrayList(u32),
+        entries: std.ArrayList(PoolEntry),
+        entries_free: std.ArrayList(u32),
 
         pub fn init(initial_count: u32, allocator: std.mem.Allocator) !Self {
-            var entries: ArrayList(PoolEntry) = .empty;
+            var entries: std.ArrayList(PoolEntry) = .empty;
             var entries_slice = try entries.addManyAsSlice(allocator, initial_count);
             for (0..initial_count) |i| {
                 entries_slice[i].is_used = false;
@@ -34,7 +31,7 @@ pub fn Pool(comptime PooledType: type) type {
                 };
             }
 
-            var entries_free: ArrayList(u32) = .empty;
+            var entries_free: std.ArrayList(u32) = .empty;
             var entries_free_slice = try entries_free.addManyAsSlice(allocator, initial_count);
             for (0..initial_count) |i| {
                 entries_free_slice[i] = @intCast(i);


### PR DESCRIPTION
Todo:
- [x] Migrate build system.
- [x] Migrate to new std.Io.Reader/Writer interfaces
- [x] Change how we import ArrayList.
- [x] Use zig version 0.15.1 in Github actions.
- [x] Solve crash in cube example after updating to SDL version 3.2.20. The crash only happens in debug builds. (This bug has been fixed in SDL master, we may just wait for the next version to drop before merging this PR.)
- [x] Bump version.