### PR TITLE
Dependency injection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *std.Build) !void {
     const exe_build_options = b.addOptions();
     exe_build_options.addOption(bool, "internal", internal);
     exe_build_options.addOption([]const u8, "lib_base_name", lib_base_name);
+    const exe_build_options_mod = exe_build_options.createModule();
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "internal", internal);
@@ -26,7 +27,7 @@ pub fn build(b: *std.Build) !void {
     linkImgui(b, playground_mod, target, optimize, internal);
 
     // Main executable.
-    const exe = buildExecutable(b, b, "gamedev-playground", exe_build_options, target, optimize, playground_mod);
+    const exe = buildExecutable(b, b, "gamedev-playground", exe_build_options_mod, target, optimize, playground_mod);
     b.installArtifact(exe);
 
     // Tests.
@@ -63,7 +64,7 @@ pub fn buildExecutable(
     b: *std.Build,
     client_b: *std.Build,
     name: []const u8,
-    build_options: *std.Build.Step.Options,
+    build_options_mod: *std.Build.Module,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
     playground_mod: *std.Build.Module,
@@ -76,7 +77,7 @@ pub fn buildExecutable(
             .{ .name = "playground", .module = playground_mod },
         },
     });
-    module.addOptions("build_options", build_options);
+    module.addImport("build_options", build_options_mod);
     const exe = b.addExecutable(.{
         .name = name,
         .root_module = module,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .gamedev_playground,
-    .version = "0.7.0",
+    .version = "0.8.0",
     .minimum_zig_version = "0.15.2",
     .fingerprint = 0x4d0121353119f6fd,
     .dependencies = .{

--- a/examples/cube/build.zig
+++ b/examples/cube/build.zig
@@ -10,24 +10,24 @@ const SHADERS: []const []const u8 = &.{
 };
 
 pub fn build(b: *std.Build) !void {
+    const build_options = b.addOptions();
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const internal = b.option(bool, "internal", "include debug interface") orelse true;
     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
     const lib_base_name = b.option([]const u8, "lib_base_name", "name of the shared library") orelse "cube";
     const log_allocations = b.option(bool, "log_allocations", "log all allocations") orelse false;
-
-    const build_options = b.addOptions();
     build_options.addOption(bool, "internal", internal);
     build_options.addOption([]const u8, "lib_base_name", lib_base_name);
     build_options.addOption(bool, "log_allocations", log_allocations);
+    const build_options_mod = build_options.createModule();
 
     const module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
-    module.addOptions("build_options", build_options);
+    module.addImport("build_options", build_options_mod);
 
     const lib = b.addLibrary(.{
         .linkage = .dynamic,
@@ -49,6 +49,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
     const playground_mod = playground_dep.module("playground");
+    playground_mod.addImport("build_options", build_options_mod);
     module.addImport("playground", playground_mod);
     gamedev_playground.linkSDL(playground_dep.builder, lib, target, optimize);
 
@@ -57,7 +58,7 @@ pub fn build(b: *std.Build) !void {
             playground_dep.builder,
             b,
             "cube",
-            build_options,
+            build_options_mod,
             target,
             optimize,
             playground_mod,

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -251,8 +251,12 @@ const FragmentUniforms = struct {
     screen_effect: u32,
 };
 
-pub export fn init(window_width: u32, window_height: u32, window: *sdl.SDL_Window) GameLib.GameStatePtr {
-    sdl_utils.logError(sdl.SDL_SetWindowTitle(window, "Cube"), "Failed to set window title");
+pub export fn getSettings() GameLib.Settings {
+    return .{ .dependencies = .Minimal };
+}
+
+pub export fn init(dependencies: GameLib.Dependencies.Minimal) GameLib.GameStatePtr {
+    sdl_utils.logError(sdl.SDL_SetWindowTitle(dependencies.window, "Cube"), "Failed to set window title");
 
     var backing_allocator = std.heap.page_allocator;
     var game_allocator = (backing_allocator.create(DebugAllocator) catch @panic("Failed to initialize game allocator."));
@@ -280,9 +284,9 @@ pub export fn init(window_width: u32, window_height: u32, window: *sdl.SDL_Windo
     state.* = .{
         .allocator = allocator,
         .game_allocator = game_allocator,
-        .window = window,
-        .window_width = window_width,
-        .window_height = window_height,
+        .window = dependencies.window,
+        .window_width = dependencies.window_width,
+        .window_height = dependencies.window_height,
         .device = device.?,
         .time = sdl.SDL_GetTicks(),
         .camera = undefined,
@@ -314,7 +318,12 @@ pub export fn init(window_width: u32, window_height: u32, window: *sdl.SDL_Windo
     submitQuadData(state);
 
     if (INTERNAL) {
-        imgui.initGPU(state.window, state.device, @floatFromInt(window_width), @floatFromInt(window_height));
+        imgui.initGPU(
+            state.window,
+            state.device,
+            @floatFromInt(state.window_width),
+            @floatFromInt(state.window_height),
+        );
     }
 
     return state;

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -428,13 +428,12 @@ pub export fn processInput(state_ptr: GameLib.GameStatePtr) bool {
     return continue_running;
 }
 
-pub export fn tick(state_ptr: GameLib.GameStatePtr) void {
+pub export fn tick(state_ptr: GameLib.GameStatePtr, time: u64, delta_time: u64) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
 
-    const new_time: u64 = sdl.SDL_GetTicks();
-    state.delta_time_actual = new_time - state.time;
+    state.time = time;
+    state.delta_time_actual = delta_time;
     state.delta_time = if (state.paused) 0 else state.delta_time_actual;
-    state.time = new_time;
 
     if (INTERNAL) {
         state.internal.fps_window.addFrameTime(sdl.SDL_GetPerformanceCounter());

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -33,7 +33,6 @@ const DebugAllocator = std.heap.DebugAllocator(.{
 pub const State = struct {
     dependencies: GameLib.Dependencies.Full3D,
 
-    game_allocator: *DebugAllocator,
     allocator: std.mem.Allocator,
 
     window: *sdl.SDL_Window,
@@ -275,7 +274,6 @@ pub export fn init(dependencies: GameLib.Dependencies.Full3D) GameLib.GameStateP
     var state: *State = allocator.create(State) catch @panic("Out of memory.");
     state.* = .{
         .allocator = allocator,
-        .game_allocator = game_allocator,
         .dependencies = dependencies,
         .window = dependencies.window,
         .device = dependencies.gpu_device,

--- a/examples/diamonds/build.zig
+++ b/examples/diamonds/build.zig
@@ -2,24 +2,24 @@ const std = @import("std");
 const gamedev_playground = @import("gamedev_playground");
 
 pub fn build(b: *std.Build) void {
+    const build_options = b.addOptions();
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const internal = b.option(bool, "internal", "include debug interface") orelse true;
     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
     const lib_base_name = b.option([]const u8, "lib_base_name", "name of the shared library") orelse "diamonds";
     const log_allocations = b.option(bool, "log_allocations", "log all allocations") orelse false;
-
-    const build_options = b.addOptions();
     build_options.addOption(bool, "internal", internal);
     build_options.addOption([]const u8, "lib_base_name", lib_base_name);
     build_options.addOption(bool, "log_allocations", log_allocations);
+    const build_options_mod = build_options.createModule();
 
     const module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
-    module.addOptions("build_options", build_options);
+    module.addImport("build_options", build_options_mod);
 
     const lib = b.addLibrary(.{
         .linkage = .dynamic,
@@ -41,6 +41,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const playground_mod = playground_dep.module("playground");
+    playground_mod.addImport("build_options", build_options_mod);
     module.addImport("playground", playground_mod);
     gamedev_playground.linkSDL(playground_dep.builder, lib, target, optimize);
 
@@ -49,7 +50,7 @@ pub fn build(b: *std.Build) void {
             playground_dep.builder,
             b,
             "diamonds",
-            build_options,
+            build_options_mod,
             target,
             optimize,
             playground_mod,

--- a/examples/diamonds/src/internal.zig
+++ b/examples/diamonds/src/internal.zig
@@ -41,10 +41,8 @@ const WINDOW_WIDTH_ADDITIONAL = 300;
 var initial_window_width: u32 = 0;
 
 pub const InternalState = struct {
-    debug_allocator: *game.DebugAllocator,
     allocator: std.mem.Allocator,
     output: *playground.internal.DebugOutputWindow,
-    fps_window: *playground.internal.FPSWindow,
 
     input: DebugInput,
     mode: enum(u8) {
@@ -69,19 +67,12 @@ pub const InternalState = struct {
 
     should_restart: bool,
 
-    pub fn init(backing_allocator: std.mem.Allocator) !*InternalState {
-        const debug_allocator =
-            (backing_allocator.create(game.DebugAllocator) catch @panic("Failed to initialize debug allocator."));
-        debug_allocator.* = .init;
-
-        var allocator = debug_allocator.allocator();
+    pub fn init(allocator: std.mem.Allocator) !*InternalState {
         var state: *InternalState = allocator.create(InternalState) catch @panic("Out of memory.");
 
         state.* = .{
-            .debug_allocator = debug_allocator,
             .allocator = allocator,
             .output = allocator.create(playground.internal.DebugOutputWindow) catch @panic("Out of memory"),
-            .fps_window = allocator.create(playground.internal.FPSWindow) catch @panic("Failed to allocate FPS state."),
 
             .input = DebugInput{},
 
@@ -104,10 +95,6 @@ pub const InternalState = struct {
 
             .should_restart = false,
         };
-
-        state.output.init();
-
-        state.fps_window.init(sdl.SDL_GetPerformanceFrequency());
 
         _ = try std.fmt.bufPrintZ(&state.current_level_name, "level1", .{});
 
@@ -172,7 +159,7 @@ pub fn processInputEvent(state: *State, event: sdl.SDL_Event) void {
     if (event.type == sdl.SDL_EVENT_KEY_DOWN) {
         switch (event.key.key) {
             sdl.SDLK_F1 => {
-                state.internal.fps_window.cycleMode();
+                state.dependencies.internal.fps_window.cycleMode();
             },
             sdl.SDLK_F2 => {
                 state.internal.memory_usage_display = !state.internal.memory_usage_display;
@@ -250,7 +237,7 @@ pub fn updateWindowSize(state: *State) void {
                 _ = sdl.SDL_SetWindowPosition(state.window, x, y);
                 _ = sdl.SDL_SetWindowSize(state.window, width, height);
 
-                state.internal.fps_window.position =
+                state.dependencies.internal.fps_window.position =
                     if (state.internal.show_sidebar)
                         .{ .x = 225, .y = -5 }
                     else
@@ -393,15 +380,15 @@ pub fn recordMemoryUsage(state: *State) void {
             state.internal.memory_usage_current_index = 0;
         }
         state.internal.memory_usage[state.internal.memory_usage_current_index] =
-            state.game_allocator.total_requested_bytes;
+            state.dependencies.game_allocator.total_requested_bytes;
     }
 }
 
 pub fn drawDebugUI(state: *State) void {
     imgui.newFrame();
 
-    state.internal.fps_window.draw();
-    state.internal.output.draw();
+    state.dependencies.internal.fps_window.draw();
+    state.dependencies.internal.output.draw();
 
     if (state.internal.show_sidebar) {
         {

--- a/examples/diamonds/src/internal.zig
+++ b/examples/diamonds/src/internal.zig
@@ -37,9 +37,8 @@ const MAX_FRAME_TIME_COUNT: u32 = 300;
 const MAX_MEMORY_USAGE_COUNT: u32 = 1000;
 const MEMORY_USAGE_RECORD_INTERVAL: u64 = 16;
 const LEVEL_NAME_BUFFER_SIZE = game.LEVEL_NAME_BUFFER_SIZE;
-const WINDOW_WIDTH = game.WINDOW_WIDTH;
-const WINDOW_HEIGHT = game.WINDOW_HEIGHT;
 const WINDOW_WIDTH_ADDITIONAL = 300;
+var initial_window_width: u32 = 0;
 
 pub const InternalState = struct {
     debug_allocator: *game.DebugAllocator,
@@ -231,15 +230,17 @@ pub fn updateWindowSize(state: *State) void {
     var height: c_int = 0;
     const show_sidebar: bool = state.internal.show_sidebar;
 
+    if (initial_window_width == 0) initial_window_width = game.settings.window_width;
+
     if (sdl.SDL_GetWindowPosition(state.window, &x, &y)) {
         if (sdl.SDL_GetWindowSize(state.window, &width, &height)) {
             var needs_change: bool = false;
 
-            if (show_sidebar and width == WINDOW_WIDTH) {
+            if (show_sidebar and width == game.settings.window_width) {
                 needs_change = true;
                 x -= WINDOW_WIDTH_ADDITIONAL;
                 width += WINDOW_WIDTH_ADDITIONAL;
-            } else if (!show_sidebar and width > WINDOW_WIDTH) {
+            } else if (!show_sidebar and width > initial_window_width) {
                 needs_change = true;
                 x += WINDOW_WIDTH_ADDITIONAL;
                 width -= WINDOW_WIDTH_ADDITIONAL;

--- a/examples/diamonds/src/internal.zig
+++ b/examples/diamonds/src/internal.zig
@@ -247,16 +247,6 @@ pub fn updateWindowSize(state: *State) void {
     }
 }
 
-pub fn resetWindowPosition(state: *State) void {
-    if (state.internal.show_sidebar) {
-        var x: c_int = 0;
-        var y: c_int = 0;
-        if (sdl.SDL_GetWindowPosition(state.window, &x, &y)) {
-            _ = sdl.SDL_SetWindowPosition(state.window, x + WINDOW_WIDTH_ADDITIONAL, y);
-        }
-    }
-}
-
 pub fn handleInput(state: *State, allocator: std.mem.Allocator) void {
     state.internal.hovered_entity_id = getHoveredEntity(state);
 

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -299,8 +299,12 @@ pub const Assets = struct {
     }
 };
 
-pub export fn init(window_width: u32, window_height: u32, window: *sdl.SDL_Window) GameLib.GameStatePtr {
-    sdl_utils.logError(sdl.SDL_SetWindowTitle(window, "Diamonds"), "Failed to set window title");
+pub export fn getSettings() GameLib.Settings {
+    return .{ .dependencies = .Minimal };
+}
+
+pub export fn init(dependencies: GameLib.Dependencies.Minimal) GameLib.GameStatePtr {
+    sdl_utils.logError(sdl.SDL_SetWindowTitle(dependencies.window, "Diamonds"), "Failed to set window title");
 
     var backing_allocator = std.heap.page_allocator;
     var game_allocator = (backing_allocator.create(DebugAllocator) catch @panic("Failed to initialize game allocator."));
@@ -319,11 +323,11 @@ pub export fn init(window_width: u32, window_height: u32, window: *sdl.SDL_Windo
         .allocator = allocator,
         .game_allocator = game_allocator,
 
-        .window = window,
-        .renderer = sdl_utils.panicIfNull(sdl.SDL_CreateRenderer(window, null), "Failed to create renderer.").?,
+        .window = dependencies.window,
+        .renderer = sdl_utils.panicIfNull(sdl.SDL_CreateRenderer(dependencies.window, null), "Failed to create renderer.").?,
 
-        .window_width = window_width,
-        .window_height = window_height,
+        .window_width = dependencies.window_width,
+        .window_height = dependencies.window_height,
 
         .world_scale = 1,
         .ui_scale = 1,
@@ -380,11 +384,11 @@ pub fn restart(state: *State) void {
         *State,
         @ptrCast(
             @alignCast(
-                init(
-                    state.window_width,
-                    state.window_height,
-                    state.window,
-                ),
+                init(.{
+                    .window_width = state.window_width,
+                    .window_height = state.window_height,
+                    .window = state.window,
+                }),
             ),
         ),
     ).*;

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -385,19 +385,17 @@ pub fn restart(state: *State) void {
 }
 
 pub export fn deinit(state_ptr: GameLib.GameStatePtr) void {
-    const state: *State = @ptrCast(@alignCast(state_ptr));
-
-    if (INTERNAL) {
-        internal.resetWindowPosition(state);
-    }
+    _ = state_ptr;
 }
 
 pub fn setupRenderTexture(state: *State) void {
-    _ = sdl.SDL_GetWindowSize(state.window, @ptrCast(&settings.window_width), @ptrCast(&settings.window_height));
-    state.world_scale = @as(f32, @floatFromInt(settings.window_height)) / @as(f32, @floatFromInt(state.world_height));
+    var window_width: c_int = 0;
+    var window_height: c_int = 0;
+    _ = sdl.SDL_GetWindowSize(state.window, &window_width, &window_height);
+    state.world_scale = @as(f32, @floatFromInt(window_height)) / @as(f32, @floatFromInt(state.world_height));
 
     var horizontal_offset: f32 =
-        (@as(f32, @floatFromInt(settings.window_width)) -
+        (@as(f32, @floatFromInt(window_width)) -
             (@as(f32, @floatFromInt(state.world_width)) * state.world_scale)) / 2;
 
     if (INTERNAL) {

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -46,8 +46,6 @@ pub const DebugAllocator = std.heap.DebugAllocator(.{
 const INTERNAL: bool = @import("build_options").internal;
 const LOG_ALLOCATIONS: bool = @import("build_options").log_allocations;
 const MAX_ENTITY_COUNT = entities.MAX_ENTITY_COUNT;
-pub const WINDOW_WIDTH = 800;
-pub const WINDOW_HEIGHT = 600;
 const WORLD_WIDTH: u32 = 200;
 const WORLD_HEIGHT: u32 = 150;
 const BALL_VELOCITY: f32 = 64;
@@ -296,7 +294,7 @@ pub const Assets = struct {
     }
 };
 
-var settings: GameLib.Settings = .{
+pub var settings: GameLib.Settings = .{
     .title = "Diamonds",
     .dependencies = .Minimal,
 };
@@ -352,8 +350,6 @@ pub export fn init(dependencies: GameLib.Dependencies.Minimal) GameLib.GameState
         .current_title_id = null,
     };
 
-    _ = sdl.SDL_SetWindowSize(state.window, WINDOW_WIDTH, WINDOW_HEIGHT);
-
     if (INTERNAL) {
         state.internal = internal.InternalState.init(backing_allocator) catch @panic("Failed to init internal state.");
         internal.updateWindowSize(state);
@@ -387,8 +383,6 @@ pub fn restart(state: *State) void {
         @ptrCast(
             @alignCast(
                 init(.{
-                    .window_width = settings.window_width,
-                    .window_height = settings.window_height,
                     .window = state.window,
                 }),
             ),

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -532,16 +532,17 @@ pub export fn processInput(state_ptr: GameLib.GameStatePtr) bool {
     return continue_running;
 }
 
-pub export fn tick(state_ptr: GameLib.GameStatePtr) void {
+pub export fn tick(state_ptr: GameLib.GameStatePtr, time: u64, delta_time_int: u64) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
 
-    state.delta_time_actual = sdl.SDL_GetTicks() - state.time;
+    state.delta_time_actual = delta_time_int;
+    state.time = time;
+
     if (!state.paused and !state.pausedDueToTitle() and !state.pausedDueToEditor()) {
         state.delta_time = state.delta_time_actual;
     } else {
         state.delta_time = 0;
     }
-    state.time = sdl.SDL_GetTicks();
 
     if (INTERNAL) {
         state.internal.fps_window.addFrameTime(sdl.SDL_GetPerformanceCounter());

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -11,6 +11,7 @@ pub fn build(b: *std.Build) void {
     const lib_base_name = b.option([]const u8, "lib_base_name", "name of the shared library") orelse "template";
     build_options.addOption(bool, "internal", internal);
     build_options.addOption([]const u8, "lib_base_name", lib_base_name);
+    const build_options_mod = build_options.createModule();
 
     // Game library.
     const module = b.createModule(.{
@@ -18,7 +19,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    module.addOptions("build_options", build_options);
+    module.addImport("build_options", build_options_mod);
 
     const lib = b.addLibrary(.{
         .linkage = .dynamic,
@@ -47,6 +48,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const playground_mod = playground_dep.module("playground");
+    playground_mod.addImport("build_options", build_options_mod);
     module.addImport("playground", playground_mod);
     gamedev_playground.linkSDL(playground_dep.builder, lib, target, optimize);
 
@@ -55,7 +57,7 @@ pub fn build(b: *std.Build) void {
             playground_dep.builder,
             b,
             "template",
-            build_options,
+            build_options_mod,
             target,
             optimize,
             playground_mod,

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -32,6 +32,7 @@ const State = struct {
         };
 
         if (INTERNAL) {
+            imgui.setup(state.dependencies.internal.imgui_context, .Renderer);
             state.internal.output = dependencies.internal.output;
         }
 
@@ -50,49 +51,22 @@ pub export fn getSettings() GameLib.Settings {
 
 pub export fn init(dependencies: GameLib.Dependencies.All2D) GameLib.GameStatePtr {
     const state: *State = State.create(dependencies) catch @panic("Failed to init state.");
-
-    if (INTERNAL) {
-        imgui.init(
-            state.dependencies.window,
-            state.dependencies.renderer,
-            @floatFromInt(settings.window_width),
-            @floatFromInt(settings.window_height),
-        );
-    }
-
     return state;
 }
 
 pub export fn deinit(state_ptr: GameLib.GameStatePtr) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
-
-    if (INTERNAL) {
-        imgui.deinit();
-    }
-
-    sdl.SDL_DestroyRenderer(state.dependencies.renderer);
+    _ = state;
 }
 
 pub export fn willReload(state_ptr: GameLib.GameStatePtr) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
     _ = state;
-
-    if (INTERNAL) {
-        imgui.deinit();
-    }
 }
 
 pub export fn reloaded(state_ptr: GameLib.GameStatePtr) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
-
-    if (INTERNAL) {
-        imgui.init(
-            state.dependencies.window,
-            state.dependencies.renderer,
-            @floatFromInt(settings.window_width),
-            @floatFromInt(settings.window_height),
-        );
-    }
+    _ = state;
 }
 
 pub export fn processInput(state_ptr: GameLib.GameStatePtr) bool {

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -17,6 +17,10 @@ const State = struct {
     window: *sdl.SDL_Window,
     renderer: *sdl.SDL_Renderer,
 
+    // Time.
+    time: u64,
+    delta_time: u64,
+
     // Input.
     space_is_down: bool,
 
@@ -47,6 +51,9 @@ pub export fn init(dependencies: GameLib.Dependencies.All2D) GameLib.GameStatePt
 
         .window = dependencies.window,
         .renderer = dependencies.renderer,
+
+        .time = 0,
+        .delta_time = 0,
 
         .space_is_down = false,
     };
@@ -137,8 +144,10 @@ pub export fn processInput(state_ptr: GameLib.GameStatePtr) bool {
     return continue_running;
 }
 
-pub export fn tick(state_ptr: GameLib.GameStatePtr) void {
+pub export fn tick(state_ptr: GameLib.GameStatePtr, time: u64, delta_time: u64) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
+    state.time = time;
+    state.delta_time = delta_time;
 
     if (INTERNAL) {
         state.internal.fps_window.addFrameTime(sdl.SDL_GetPerformanceCounter());

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -11,7 +11,7 @@ const GameLib = playground.GameLib;
 const DebugAllocator = GameLib.DebugAllocator;
 
 const State = struct {
-    dependencies: GameLib.Dependencies.All2D,
+    dependencies: GameLib.Dependencies.Full2D,
 
     // Time.
     time: u64 = 0,
@@ -25,7 +25,7 @@ const State = struct {
         output: *playground.internal.DebugOutputWindow = undefined,
     } else extern struct {} = undefined,
 
-    pub fn create(dependencies: GameLib.Dependencies.All2D) !*State {
+    pub fn create(dependencies: GameLib.Dependencies.Full2D) !*State {
         const state: *State = try dependencies.game_allocator.allocator().create(State);
         state.* = .{
             .dependencies = dependencies,
@@ -42,14 +42,14 @@ const State = struct {
 
 const settings: GameLib.Settings = .{
     .title = "Template",
-    .dependencies = .All2D,
+    .dependencies = .Full2D,
 };
 
 pub export fn getSettings() GameLib.Settings {
     return settings;
 }
 
-pub export fn init(dependencies: GameLib.Dependencies.All2D) GameLib.GameStatePtr {
+pub export fn init(dependencies: GameLib.Dependencies.Full2D) GameLib.GameStatePtr {
     const state: *State = State.create(dependencies) catch @panic("Failed to init state.");
     return state;
 }

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -16,8 +16,6 @@ const State = struct {
 
     window: *sdl.SDL_Window,
     renderer: *sdl.SDL_Renderer,
-    window_width: u32,
-    window_height: u32,
 
     // Input.
     space_is_down: bool,
@@ -30,8 +28,13 @@ const State = struct {
     } else struct {} = undefined,
 };
 
+const settings: GameLib.Settings = .{
+    .title = "Template",
+    .dependencies = .All2D,
+};
+
 pub export fn getSettings() GameLib.Settings {
-    return .{ .dependencies = .All2D };
+    return settings;
 }
 
 pub export fn init(dependencies: GameLib.Dependencies.All2D) GameLib.GameStatePtr {
@@ -44,8 +47,6 @@ pub export fn init(dependencies: GameLib.Dependencies.All2D) GameLib.GameStatePt
 
         .window = dependencies.window,
         .renderer = dependencies.renderer,
-        .window_width = dependencies.window_width,
-        .window_height = dependencies.window_height,
 
         .space_is_down = false,
     };
@@ -56,7 +57,12 @@ pub export fn init(dependencies: GameLib.Dependencies.All2D) GameLib.GameStatePt
         state.internal.output = dependencies.internal.output;
         state.internal.fps_window = dependencies.internal.fps_window;
 
-        imgui.init(state.window, state.renderer, @floatFromInt(state.window_width), @floatFromInt(state.window_height));
+        imgui.init(
+            state.window,
+            state.renderer,
+            @floatFromInt(settings.window_width),
+            @floatFromInt(settings.window_height),
+        );
     }
 
     return state;
@@ -85,7 +91,12 @@ pub export fn reloaded(state_ptr: GameLib.GameStatePtr) void {
     const state: *State = @ptrCast(@alignCast(state_ptr));
 
     if (INTERNAL) {
-        imgui.init(state.window, state.renderer, @floatFromInt(state.window_width), @floatFromInt(state.window_height));
+        imgui.init(
+            state.window,
+            state.renderer,
+            @floatFromInt(settings.window_width),
+            @floatFromInt(settings.window_height),
+        );
     }
 }
 

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -30,7 +30,7 @@ pub const Settings = extern struct {
 /// List of dependency sets available to receive on startup.
 pub const DependenciesType = enum(u32) {
     Minimal,
-    All2D,
+    Full2D,
 };
 
 /// These structs define different sets of dependencies that can be provided to your library on startup.
@@ -41,7 +41,7 @@ pub const Dependencies = struct {
     };
 
     /// A batteries included set of dependencies for 2D rendering, preferable in most cases.
-    pub const All2D = extern struct {
+    pub const Full2D = extern struct {
         game_allocator: *DebugAllocator,
         window: *sdl.SDL_Window,
         renderer: *sdl.SDL_Renderer,
@@ -71,7 +71,7 @@ getSettings: *const fn () callconv(.c) Settings = undefined,
 initMinimal: *const fn (Dependencies.Minimal) callconv(.c) GameStatePtr = undefined,
 /// Called when the game starts, use to setup your game state and return a pointer to it which will be held by the main
 /// executable and passed to all subsequent calls into the game. Includes a full set of dependencies for 2D games.
-initAll2D: *const fn (Dependencies.All2D) callconv(.c) GameStatePtr = undefined,
+initFull2D: *const fn (Dependencies.Full2D) callconv(.c) GameStatePtr = undefined,
 
 /// Called just before the game exits.
 deinit: *const fn (GameStatePtr) callconv(.c) void = undefined,
@@ -90,7 +90,7 @@ draw: *const fn (GameStatePtr) callconv(.c) void = undefined,
 pub fn load(self: *@This(), dyn_lib: *std.DynLib) !void {
     self.getSettings = dyn_lib.lookup(@TypeOf(self.getSettings), "getSettings") orelse return error.LookupFail;
     self.initMinimal = dyn_lib.lookup(@TypeOf(self.initMinimal), "init") orelse return error.LookupFail;
-    self.initAll2D = dyn_lib.lookup(@TypeOf(self.initAll2D), "init") orelse return error.LookupFail;
+    self.initFull2D = dyn_lib.lookup(@TypeOf(self.initFull2D), "init") orelse return error.LookupFail;
 
     self.deinit = dyn_lib.lookup(@TypeOf(self.deinit), "deinit") orelse return error.LookupFail;
 

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -16,7 +16,14 @@ pub const DebugAllocator = std.heap.DebugAllocator(.{
 
 /// Settings that your game library can define.
 pub const Settings = extern struct {
-    dependencies: DependenciesType,
+    title: [*c]const u8 = "Playground",
+    window_width: u32 = if (INTERNAL) 800 else 1600,
+    window_height: u32 = if (INTERNAL) 600 else 1200,
+    window_floating: bool = INTERNAL,
+    window_on_top: bool = INTERNAL,
+    fullscreen: bool = !INTERNAL,
+    target_frame_rate: u32 = 120,
+    dependencies: DependenciesType = .Minimal,
 };
 
 /// List of dependency sets available to receive on startup.

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -82,7 +82,7 @@ reloaded: *const fn (GameStatePtr) callconv(.c) void = undefined,
 
 /// Called on every frame, return false from it to exit the game.
 processInput: *const fn (GameStatePtr) callconv(.c) bool = undefined,
-tick: *const fn (GameStatePtr) callconv(.c) void = undefined,
+tick: *const fn (GameStatePtr, time: u64, delta_time: u64) callconv(.c) void = undefined,
 draw: *const fn (GameStatePtr) callconv(.c) void = undefined,
 
 pub fn load(self: *@This(), dyn_lib: *std.DynLib) !void {

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -37,8 +37,6 @@ pub const Dependencies = struct {
     /// A minimal set of dependencies, suitable when you want to do everything yourself.
     pub const Minimal = extern struct {
         window: *sdl.SDL_Window,
-        window_width: u32,
-        window_height: u32,
     };
 
     /// A batteries included set of dependencies for 2D rendering, preferable in most cases.
@@ -46,8 +44,6 @@ pub const Dependencies = struct {
         game_allocator: *DebugAllocator,
         window: *sdl.SDL_Window,
         renderer: *sdl.SDL_Renderer,
-        window_width: u32,
-        window_height: u32,
 
         internal: if (INTERNAL) extern struct {
             debug_allocator: *DebugAllocator = undefined,

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -2,6 +2,7 @@
 //! game library (most likely the `root.zig` file) and marking them with `pub export`.
 const std = @import("std");
 const sdl = @import("sdl.zig").c;
+const imgui = @import("imgui.zig").c;
 const internal = @import("internal.zig");
 
 // Build options.
@@ -46,6 +47,7 @@ pub const Dependencies = struct {
         renderer: *sdl.SDL_Renderer,
 
         internal: if (INTERNAL) extern struct {
+            imgui_context: *imgui.ImGuiContext = undefined,
             debug_allocator: *DebugAllocator = undefined,
             output: *internal.DebugOutputWindow = undefined,
             fps_window: *internal.FPSWindow = undefined,

--- a/src/lib/docs.zig
+++ b/src/lib/docs.zig
@@ -17,12 +17,14 @@
 //! const build_options = b.addOptions();
 //! build_options.addOption(bool, "internal", internal);
 //! build_options.addOption([]const u8, "lib_base_name", lib_base_name);
+//! const build_options_mod = build_options.createModule();
 //!
 //! const playground_dep = b.dependency("gamedev_playground", .{
 //!     .target = target,
 //!     .optimize = optimize,
 //! });
 //! const playground_mod = playground_dep.module("playground");
+//! playground_mod.addImport("build_options", build_options_mod);
 //! module.addImport("playground", playground_mod);
 //! gamedev_playground.linkSDL(playground_dep.builder, lib, target, optimize);
 //!
@@ -31,7 +33,7 @@
 //!         playground_dep.builder,
 //!         b,
 //!         "YOUR_EXECUTABLE_NAME",
-//!         build_options,
+//!         build_options_mod,
 //!         target,
 //!         optimize,
 //!         playground_mod,

--- a/src/main.zig
+++ b/src/main.zig
@@ -80,7 +80,7 @@ pub fn main() !void {
                 .window = window.?,
             });
         },
-        .All2D => {
+        .Full2D => {
             const game_allocator = backing_allocator.create(GameLib.DebugAllocator) catch
                 @panic("Failed to initialize game allocator.");
             game_allocator.* = .init;
@@ -90,7 +90,7 @@ pub fn main() !void {
                 "Failed to create renderer.",
             );
 
-            var dependencies: GameLib.Dependencies.All2D = .{
+            var dependencies: GameLib.Dependencies.Full2D = .{
                 .game_allocator = game_allocator,
                 .window = window.?,
                 .renderer = game_renderer.?,
@@ -117,7 +117,7 @@ pub fn main() !void {
                 dependencies.internal.imgui_context = imgui.context.?;
             }
 
-            state = game.initAll2D(dependencies);
+            state = game.initFull2D(dependencies);
         },
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -122,10 +122,12 @@ pub fn main() !void {
         initChangeTimes(allocator);
     }
 
+    var previous_frame_start_time: u64 = 0;
     var frame_start_time: u64 = 0;
     var frame_elapsed_time: u64 = 0;
     while (true) {
         frame_start_time = sdl.SDL_GetTicks();
+        const delta_time = frame_start_time - previous_frame_start_time;
 
         if (INTERNAL) {
             checkForChanges(state, allocator);
@@ -135,7 +137,7 @@ pub fn main() !void {
             break;
         }
 
-        game.tick(state);
+        game.tick(state, frame_start_time, delta_time);
         game.draw(state);
 
         frame_elapsed_time = sdl.SDL_GetTicks() - frame_start_time;
@@ -145,6 +147,7 @@ pub fn main() !void {
                 sdl.SDL_Delay(@intCast(target_frame_time - frame_elapsed_time));
             }
         }
+        previous_frame_start_time = frame_start_time;
     }
 
     game.deinit(state);

--- a/src/main.zig
+++ b/src/main.zig
@@ -79,8 +79,6 @@ pub fn main() !void {
         .Minimal => {
             state = game.initMinimal(.{
                 .window = window.?,
-                .window_width = game_settings.window_width,
-                .window_height = game_settings.window_height,
             });
         },
         .All2D => {
@@ -97,8 +95,6 @@ pub fn main() !void {
                 .game_allocator = game_allocator,
                 .window = window.?,
                 .renderer = renderer.?,
-                .window_width = game_settings.window_width,
-                .window_height = game_settings.window_height,
             };
 
             if (INTERNAL) {


### PR DESCRIPTION
Allow each game to define which set of dependencies it wants to receive on startup. The aim is to put together a few sets for different use cases which include things that otherwise have to be done in every new game. This reduces duplication of code and allows for getting started even quicker.

## Todo:
- [x] When injecting internal dependencies like FPSWindow, should we manage their lifecycle (update, draw etc) in the executable also?
	- [x] This would require exposing a new function that only draws imgui windows which force the user to draw the imgui windows separately. The way we have it now allows for composing imgui however you see fit.
- [x] Can we manage the imgui lifecycle in the executable in those cases also?
- [x] Should the Template example simply keep the whole `Dependencies.All2D` struct in its state instead of duplicating all the same fields? Seems like that would make the `State` struct cleaner in that it would only contain state specific to the game.
- [x] Inject time and delta_time into the tick function.
- [x] Allow library to define more settings
	- [x] Window title.
	- [x] Initial window size.
	- [x] Initial window position.
	- [x] Target frame rate.
	- [x] Floating window.
	- [x] Fullscreen.
- [x] Remove the `window_width` and `window_height` from injected dependencies now that they flow in the opposite direction.
- [x] Return different values from getSettings for internal builds.
- [x] Consider naming of dependency sets.
- [x] Create a dependency set for 3D.
	- [x] Keep imgui in mind, we need at least a `SDL_GPUDevice` available.
- [x] Migrate other examples from the minimal when dependency sets are done.
- [x] Bump version.