### PR TITLE
Update to zig version 0.16.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: mlugg/setup-zig@v2
         with:
-            version: 0.15.2
+            version: 0.16.0
 
       - name: Build
         run: zig build docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: mlugg/setup-zig@v2
         with:
-            version: 0.15.2
+            version: 0.16.0
 
       - name: Main tests
         run: zig build test --summary all

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .zig-cache/
 zig-out/
+zig-pkg/
 /release/
 /debug/
 /build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is roughly speaking 0.MAJOR.MINOR.PATCH.
 * Added a module with utilities for dealing with the file system, to begin with it covers Flints own needs.
 * Added a simpler way to integrate the Flint build into a project build.zig by providing a single function that returns both the module and executable.
 ### Changed
+* Updated minimum Zig version to 0.16.0.
 * Updated SDL to version 3.4.4.
 * Changed where we look for the game library to make the executable more portable. The order is now: zig-out if internal build, same directory as executable, and finally a directory called "lib" in the same directory as the executable.
 * The workaround to deal with building the game library while it is open on Windows is now only applied if the library is found in the dev directory (zig-out/bin), otherwise we skip it. This allows internal builds to be portable.

--- a/build.zig
+++ b/build.zig
@@ -287,10 +287,10 @@ fn createImGuiModule(
             });
 
             dcimgui_sdl.root_module.link_libcpp = true;
-            dcimgui_sdl.addIncludePath(sdl_dep.path("include"));
-            dcimgui_sdl.addIncludePath(imgui_dep.path("."));
-            dcimgui_sdl.addIncludePath(imgui_dep.path("backends/"));
-            dcimgui_sdl.addIncludePath(dear_bindings_dep.path(""));
+            module.addIncludePath(sdl_dep.path("include"));
+            module.addIncludePath(imgui_dep.path(""));
+            module.addIncludePath(imgui_dep.path("backends/"));
+            module.addIncludePath(dear_bindings_dep.path(""));
             dcimgui_sdl.installHeadersDirectory(
                 dear_bindings_dep.path(""),
                 "",
@@ -314,7 +314,7 @@ fn createImGuiModule(
             }
 
             for (imgui_sources) |file| {
-                dcimgui_sdl.addCSourceFile(.{
+                module.addCSourceFile(.{
                     .file = file,
                     .flags = IMGUI_C_FLAGS,
                 });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .flint,
     .version = "0.10.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0x4ab03ee82392c43e,
     .dependencies = .{
         .sdl = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x4ab03ee82392c43e,
     .dependencies = .{
         .sdl = .{
-            .url = "git+https://github.com/castholm/SDL.git#v0.4.2+3.4.4",
-            .hash = "sdl-0.4.2+3.4.4-SDL--nF2pQHiRAibwjhZ6jBJu0Omc3x4EoxPn6gxfnAi",
+            .url = "git+https://github.com/castholm/SDL.git#c5ba24c694b5d520cdc1d029d8def398690d6894",
+            .hash = "sdl-0.4.2+3.4.4-SDL--kB3pQHKG_4zWG-pH04ZcZZj_IRF7dwMpxNVGwd6",
             .lazy = true,
         },
         .imgui = .{

--- a/examples/cube/build.zig.zon
+++ b/examples/cube/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .cube_example,
     .version = "0.1.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0x170c330bd4c57d43,
     .dependencies = .{
         .flint = .{

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -408,7 +408,7 @@ pub export fn draw(state_ptr: GameLib.GameStatePtr) void {
 
     // Draw to texture.
     var command_buffer: ?*sdl.SDL_GPUCommandBuffer =
-        sdl_utils.panicIfNull(sdl.SDL_AcquireGPUCommandBuffer(state.device), "Failed to acquire GPU commmand buffer");
+        sdl_utils.panicIfNull(sdl.SDL_AcquireGPUCommandBuffer(state.device), "Failed to acquire GPU command buffer");
 
     var color_target_info: sdl.SDL_GPUColorTargetInfo = .{
         .texture = state.render_texture,

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -523,7 +523,7 @@ pub export fn draw(state_ptr: GameLib.GameStatePtr) void {
                 _ = imgui.c.ImGui_Begin("Game state", null, imgui.c.ImGuiWindowFlags_NoFocusOnAppearing);
                 defer imgui.c.ImGui_End();
 
-                flint.internal.inspectStruct(state, &.{}, false, inputCustomTypes);
+                flint.internal.inspectStruct(state, &.{ "io", "allocator", "arena" }, false, inputCustomTypes);
             }
 
             imgui.renderGPU(command_buffer, swapchain_texture);

--- a/examples/cube/src/root.zig
+++ b/examples/cube/src/root.zig
@@ -11,7 +11,6 @@ const LOG_ALLOCATIONS: bool = @import("build_options").log_allocations;
 
 pub const std_options: std.Options = .{
     .log_level = if (INTERNAL) .info else .err,
-    .logFn = GameLib.logFn,
 };
 
 const Vector2 = math.Vector2;

--- a/examples/diamonds/build.zig.zon
+++ b/examples/diamonds/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .diamonds_example,
     .version = "0.1.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0x5b4abc708109fe2f,
     .dependencies = .{
         .flint = .{

--- a/examples/diamonds/src/internal.zig
+++ b/examples/diamonds/src/internal.zig
@@ -439,7 +439,7 @@ pub fn drawDebugUI(state: *State) void {
             _ = imgui.c.ImGui_Begin("Game state", null, imgui.c.ImGuiWindowFlags_NoFocusOnAppearing);
             defer imgui.c.ImGui_End();
 
-            flint.internal.inspectStruct(state, &.{"entity"}, false, &inputCustomTypes);
+            flint.internal.inspectStruct(state, &.{ "io", "allocator", "arena" }, false, &inputCustomTypes);
         }
     }
 

--- a/examples/diamonds/src/internal.zig
+++ b/examples/diamonds/src/internal.zig
@@ -527,7 +527,7 @@ pub fn drawDebugOverlay(state: *State) void {
                 const time_remaining: f32 =
                     @as(f32, @floatFromInt(((collision.time_added + show_time) - state.time))) /
                     @as(f32, @floatFromInt(show_time));
-                const color: Color = .{ 255, 128, 0, @intFromFloat(255 * time_remaining) };
+                const color: Color = .{ 255, 128, 0, @trunc(255 * time_remaining) };
                 if (state.getEntity(collision.collision.other_id)) |other_entity| {
                     drawDebugCollider(state.renderer, other_entity, color, scale, offset);
                 }
@@ -729,8 +729,8 @@ fn saveLevel(state: *State, name: []const u8) !void {
         if (entity.hasFlag(.has_block) and entity.hasFlag(.has_transform)) {
             try writer.writeInt(u32, @intFromEnum(entity.color), .little);
             try writer.writeInt(u32, @intFromEnum(entity.block_type), .little);
-            try writer.writeInt(i32, @intFromFloat(@round(entity.position[X])), .little);
-            try writer.writeInt(i32, @intFromFloat(@round(entity.position[Y])), .little);
+            try writer.writeInt(i32, @round(entity.position[X]), .little);
+            try writer.writeInt(i32, @round(entity.position[Y]), .little);
         }
     }
 

--- a/examples/diamonds/src/internal.zig
+++ b/examples/diamonds/src/internal.zig
@@ -700,18 +700,19 @@ fn getTiledPosition(position: Vector2, asset: *const AsepriteAsset) Vector2 {
 
 fn openSprite(state: *State, allocator: std.mem.Allocator, entity: *Entity) void {
     if (state.assets.getSpriteAsset(state, entity)) |sprite_asset| {
-        aseprite.openInAseprite(sprite_asset, allocator);
+        aseprite.openInAseprite(sprite_asset, allocator, state.dependencies.io.*);
     }
 }
 
 fn saveLevel(state: *State, name: []const u8) !void {
+    const io: std.Io = state.dependencies.io.*;
     var buf: [LEVEL_NAME_BUFFER_SIZE * 2]u8 = undefined;
     const path = try std.fmt.bufPrint(&buf, "assets/{s}.lvl", .{name});
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
+    const file = try std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true });
+    defer file.close(io);
 
     var writer_buf: [10 * 1024]u8 = undefined;
-    var file_writer = file.writer(&writer_buf);
+    var file_writer = file.writer(io, &writer_buf);
     var writer: *std.Io.Writer = &file_writer.interface;
 
     var walls_count: u32 = 0;

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -807,29 +807,30 @@ fn drawTextureAt(state: *State, texture: *sdl.SDL_Texture, position: Vector2, sc
 }
 
 fn loadAssets(state: *State) void {
-    state.assets.missing_sprite = .load("assets/missing_sprite.aseprite", state.renderer, state.allocator);
+    const io: std.Io = state.dependencies.io.*;
+    state.assets.missing_sprite = .load("assets/missing_sprite.aseprite", state.renderer, state.allocator, io);
 
-    state.assets.life_filled = .load("assets/life_filled.aseprite", state.renderer, state.allocator);
-    state.assets.life_outlined = .load("assets/life_outlined.aseprite", state.renderer, state.allocator);
-    state.assets.life_backdrop = .load("assets/life_backdrop.aseprite", state.renderer, state.allocator);
+    state.assets.life_filled = .load("assets/life_filled.aseprite", state.renderer, state.allocator, io);
+    state.assets.life_outlined = .load("assets/life_outlined.aseprite", state.renderer, state.allocator, io);
+    state.assets.life_backdrop = .load("assets/life_backdrop.aseprite", state.renderer, state.allocator, io);
 
-    state.assets.ball_red = .load("assets/ball_red.aseprite", state.renderer, state.allocator);
-    state.assets.ball_blue = .load("assets/ball_blue.aseprite", state.renderer, state.allocator);
+    state.assets.ball_red = .load("assets/ball_red.aseprite", state.renderer, state.allocator, io);
+    state.assets.ball_blue = .load("assets/ball_blue.aseprite", state.renderer, state.allocator, io);
 
-    state.assets.block_gray = .load("assets/block_gray.aseprite", state.renderer, state.allocator);
-    state.assets.block_red = .load("assets/block_red.aseprite", state.renderer, state.allocator);
-    state.assets.block_blue = .load("assets/block_blue.aseprite", state.renderer, state.allocator);
-    state.assets.block_change_red = .load("assets/block_change_red.aseprite", state.renderer, state.allocator);
-    state.assets.block_change_blue = .load("assets/block_change_blue.aseprite", state.renderer, state.allocator);
-    state.assets.block_deadly = .load("assets/block_deadly.aseprite", state.renderer, state.allocator);
+    state.assets.block_gray = .load("assets/block_gray.aseprite", state.renderer, state.allocator, io);
+    state.assets.block_red = .load("assets/block_red.aseprite", state.renderer, state.allocator, io);
+    state.assets.block_blue = .load("assets/block_blue.aseprite", state.renderer, state.allocator, io);
+    state.assets.block_change_red = .load("assets/block_change_red.aseprite", state.renderer, state.allocator, io);
+    state.assets.block_change_blue = .load("assets/block_change_blue.aseprite", state.renderer, state.allocator, io);
+    state.assets.block_deadly = .load("assets/block_deadly.aseprite", state.renderer, state.allocator, io);
 
-    state.assets.background = .load("assets/background.aseprite", state.renderer, state.allocator);
+    state.assets.background = .load("assets/background.aseprite", state.renderer, state.allocator, io);
 
-    state.assets.title_paused = .load("assets/title_paused.aseprite", state.renderer, state.allocator);
-    state.assets.title_get_ready = .load("assets/title_get_ready.aseprite", state.renderer, state.allocator);
-    state.assets.title_cleared = .load("assets/title_cleared.aseprite", state.renderer, state.allocator);
-    state.assets.title_death = .load("assets/title_death.aseprite", state.renderer, state.allocator);
-    state.assets.title_game_over = .load("assets/title_game_over.aseprite", state.renderer, state.allocator);
+    state.assets.title_paused = .load("assets/title_paused.aseprite", state.renderer, state.allocator, io);
+    state.assets.title_get_ready = .load("assets/title_get_ready.aseprite", state.renderer, state.allocator, io);
+    state.assets.title_cleared = .load("assets/title_cleared.aseprite", state.renderer, state.allocator, io);
+    state.assets.title_death = .load("assets/title_death.aseprite", state.renderer, state.allocator, io);
+    state.assets.title_game_over = .load("assets/title_game_over.aseprite", state.renderer, state.allocator, io);
 }
 
 fn unloadAssets(state: *State) void {
@@ -903,10 +904,10 @@ fn unloadLevel(state: *State) void {
 pub fn loadLevel(state: *State, name: []const u8) !void {
     var buf: [LEVEL_NAME_BUFFER_SIZE * 2]u8 = undefined;
     const path = try std.fmt.bufPrint(&buf, "assets/{s}.lvl", .{name});
-    const file = try flint.fs.openFileRelative(path, .{ .mode = .read_only });
+    const file = try flint.fs.openFileRelative(state.dependencies.io.*, path, .{ .mode = .read_only });
 
     var reader_buf: [10 * 1024]u8 = undefined;
-    var file_reader = file.reader(&reader_buf);
+    var file_reader = file.reader(state.dependencies.io.*, &reader_buf);
     var reader: *std.Io.Reader = &file_reader.interface;
     const wall_count = try reader.takeInt(u32, .little);
 

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -11,7 +11,6 @@ const internal = if (INTERNAL) @import("internal.zig") else struct {};
 const loggingAllocator = if (INTERNAL) @import("logging_allocator").loggingAllocator else undefined;
 pub const std_options: std.Options = .{
     .log_level = if (INTERNAL) .warn else .err,
-    .logFn = GameLib.logFn,
 };
 
 const GameLib = flint.GameLib;

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -637,7 +637,7 @@ pub export fn tick(state_ptr: GameLib.GameStatePtr, time: u64, delta_time_int: u
         // Update tweens.
         if (entity.hasFlag(.has_tween)) {
             const total_duration = entity.tween_delay + entity.tween_duration;
-            entity.tween_time_passed += @intFromFloat(delta_time_actual * 1000);
+            entity.tween_time_passed += @trunc(delta_time_actual * 1000);
 
             if (entity.tween_time_passed <= total_duration and entity.tween_delay <= entity.tween_time_passed) {
                 const t: f32 =

--- a/examples/logging_allocator.zig
+++ b/examples/logging_allocator.zig
@@ -15,7 +15,7 @@ pub fn LoggingAllocator(
 /// with the given scope on every call to the allocator.
 /// For logging to a `std.io.Writer` see `std.heap.LogToWriterAllocator`
 pub fn ScopedLoggingAllocator(
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @TypeOf(.enum_literal),
     comptime success_log_level: std.log.Level,
     comptime failure_log_level: std.log.Level,
 ) type {

--- a/examples/math.zig
+++ b/examples/math.zig
@@ -125,7 +125,7 @@ pub const Matrix4x4 = extern struct {
 };
 
 pub fn lerpU8(min: u8, max: u8, t: f32) u8 {
-    return @intFromFloat(lerp(@floatFromInt(min), @floatFromInt(max), t));
+    return @trunc(lerp(@floatFromInt(min), @floatFromInt(max), t));
 }
 
 pub fn lerp(min: f32, max: f32, t: f32) f32 {

--- a/examples/template/.gitignore
+++ b/examples/template/.gitignore
@@ -1,5 +1,6 @@
 .zig-cache/
 zig-out/
+zig-pkg/
 /release/
 /debug/
 /build/

--- a/examples/template/build.zig.zon
+++ b/examples/template/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .template,
     .version = "0.1.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0x97601f8306db8023,
     .dependencies = .{
         .flint = .{

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -260,6 +260,6 @@ fn drawInternalUI(state: *State) void {
         _ = imgui.c.ImGui_Begin("Game state", null, imgui.c.ImGuiWindowFlags_NoFocusOnAppearing);
         defer imgui.c.ImGui_End();
 
-        flint.internal.inspectStruct(state, &.{}, false, null);
+        flint.internal.inspectStruct(state, &.{ "io", "allocator", "arena" }, false, null);
     }
 }

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -6,7 +6,6 @@ const aseprite = flint.aseprite;
 
 pub const std_options: std.Options = .{
     .log_level = if (INTERNAL) .info else .err,
-    .logFn = GameLib.logFn,
 };
 
 // Build options.

--- a/examples/template/src/root.zig
+++ b/examples/template/src/root.zig
@@ -89,8 +89,12 @@ pub export fn deinit(state_ptr: GameLib.GameStatePtr) void {
 }
 
 fn loadAssets(state: *State) void {
-    state.welcome_sprite =
-        .load("assets/welcome.aseprite", state.dependencies.renderer, state.dependencies.allocator.*);
+    state.welcome_sprite = .load(
+        "assets/welcome.aseprite",
+        state.dependencies.renderer,
+        state.dependencies.allocator.*,
+        state.dependencies.io.*,
+    );
 }
 fn unloadAssets(state: *State) void {
     state.welcome_sprite.?.deinit(state.dependencies.allocator.*);
@@ -181,7 +185,7 @@ pub export fn processInput(state_ptr: GameLib.GameStatePtr) bool {
     if (state.left_mouse_pressed) {
         if (state.time - state.left_mouse_last_pressed_time < 300) {
             // TODO: Check where the double click happened so we know which sprite to open.
-            aseprite.openInAseprite(&state.welcome_sprite.?, state.dependencies.allocator.*);
+            aseprite.openInAseprite(&state.welcome_sprite.?, state.dependencies.allocator.*, state.dependencies.io.*);
         }
 
         state.left_mouse_last_pressed_time = state.time;

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -132,19 +132,3 @@ pub fn load(self: *@This(), dyn_lib: *std.DynLib) !void {
     self.tick = dyn_lib.lookup(@TypeOf(self.tick), "tick") orelse return error.LookupFail;
     self.draw = dyn_lib.lookup(@TypeOf(self.draw), "draw") orelse return error.LookupFail;
 }
-
-/// Custom logger for posix systems since the default log function doesn't work from dynamic libraries on Linux.
-pub const logFn = if (builtin.os.tag == .windows) std.log.defaultLog else posixLogFn;
-
-fn posixLogFn(
-    comptime message_level: std.log.Level,
-    comptime scope: @TypeOf(.enum_literal),
-    comptime format: []const u8,
-    args: anytype,
-) void {
-    const level_txt = comptime message_level.asText();
-    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
-    var buffer: [1024]u8 = undefined;
-    const msg = std.fmt.bufPrint(&buffer, level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
-    nosuspend _ = std.posix.write(2, msg) catch return;
-}

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -55,6 +55,7 @@ pub const Dependencies = struct {
     /// A batteries included set of dependencies for 2D rendering, preferable in most cases.
     pub const Full2D = extern struct {
         allocator: *std.mem.Allocator,
+        io: *const std.Io,
         window: *sdl.SDL_Window,
         renderer: *sdl.SDL_Renderer,
 
@@ -64,6 +65,7 @@ pub const Dependencies = struct {
     /// A batteries included set of dependencies for 2D rendering, preferable in most cases.
     pub const Full3D = extern struct {
         allocator: *std.mem.Allocator,
+        io: *const std.Io,
         window: *sdl.SDL_Window,
         gpu_device: *sdl.SDL_GPUDevice,
 

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -119,21 +119,21 @@ processInput: *const fn (GameStatePtr) callconv(.c) bool = undefined,
 tick: *const fn (GameStatePtr, time: u64, delta_time: u64) callconv(.c) void = undefined,
 draw: *const fn (GameStatePtr) callconv(.c) void = undefined,
 
-pub fn load(self: *@This(), dyn_lib: os.LoadedLibrary) !void {
+pub fn load(self: *@This(), dyn_lib: *os.LoadedLibrary) !void {
     if (PLATFORM == .windows) {
-        self.getSettings = @ptrCast(os.windows.GetProcAddress(dyn_lib, "getSettings") orelse return error.LookupFail);
-        self.initMinimal = @ptrCast(os.windows.GetProcAddress(dyn_lib, "init") orelse return error.LookupFail);
-        self.initFull2D = @ptrCast(os.windows.GetProcAddress(dyn_lib, "init") orelse return error.LookupFail);
-        self.initFull3D = @ptrCast(os.windows.GetProcAddress(dyn_lib, "init") orelse return error.LookupFail);
+        self.getSettings = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "getSettings") orelse return error.LookupFail);
+        self.initMinimal = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "init") orelse return error.LookupFail);
+        self.initFull2D = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "init") orelse return error.LookupFail);
+        self.initFull3D = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "init") orelse return error.LookupFail);
 
-        self.deinit = @ptrCast(os.windows.GetProcAddress(dyn_lib, "deinit") orelse return error.LookupFail);
+        self.deinit = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "deinit") orelse return error.LookupFail);
 
-        self.willReload = @ptrCast(os.windows.GetProcAddress(dyn_lib, "willReload") orelse return error.LookupFail);
-        self.reloaded = @ptrCast(os.windows.GetProcAddress(dyn_lib, "reloaded") orelse return error.LookupFail);
+        self.willReload = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "willReload") orelse return error.LookupFail);
+        self.reloaded = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "reloaded") orelse return error.LookupFail);
 
-        self.processInput = @ptrCast(os.windows.GetProcAddress(dyn_lib, "processInput") orelse return error.LookupFail);
-        self.tick = @ptrCast(os.windows.GetProcAddress(dyn_lib, "tick") orelse return error.LookupFail);
-        self.draw = @ptrCast(os.windows.GetProcAddress(dyn_lib, "draw") orelse return error.LookupFail);
+        self.processInput = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "processInput") orelse return error.LookupFail);
+        self.tick = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "tick") orelse return error.LookupFail);
+        self.draw = @ptrCast(os.windows.GetProcAddress(dyn_lib.*, "draw") orelse return error.LookupFail);
     } else {
         self.getSettings = dyn_lib.lookup(@TypeOf(self.getSettings), "getSettings") orelse return error.LookupFail;
         self.initMinimal = dyn_lib.lookup(@TypeOf(self.initMinimal), "init") orelse return error.LookupFail;

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -136,7 +136,7 @@ pub const logFn = if (builtin.os.tag == .windows) std.log.defaultLog else posixL
 
 fn posixLogFn(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @TypeOf(.enum_literal),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/src/lib/GameLib.zig
+++ b/src/lib/GameLib.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const sdl = @import("sdl.zig").c;
+const os = @import("os.zig");
 const imgui = if (INTERNAL) @import("imgui.zig").c else struct {
     pub const ImGuiContext: type = anyopaque;
 };
@@ -14,6 +15,7 @@ const internal = if (INTERNAL) @import("internal.zig") else struct {
 
 // Build options.
 const INTERNAL: bool = @import("build_options").internal;
+const PLATFORM = @import("builtin").os.tag;
 
 // Types.
 pub const DebugAllocator = std.heap.DebugAllocator(.{
@@ -117,18 +119,34 @@ processInput: *const fn (GameStatePtr) callconv(.c) bool = undefined,
 tick: *const fn (GameStatePtr, time: u64, delta_time: u64) callconv(.c) void = undefined,
 draw: *const fn (GameStatePtr) callconv(.c) void = undefined,
 
-pub fn load(self: *@This(), dyn_lib: *std.DynLib) !void {
-    self.getSettings = dyn_lib.lookup(@TypeOf(self.getSettings), "getSettings") orelse return error.LookupFail;
-    self.initMinimal = dyn_lib.lookup(@TypeOf(self.initMinimal), "init") orelse return error.LookupFail;
-    self.initFull2D = dyn_lib.lookup(@TypeOf(self.initFull2D), "init") orelse return error.LookupFail;
-    self.initFull3D = dyn_lib.lookup(@TypeOf(self.initFull3D), "init") orelse return error.LookupFail;
+pub fn load(self: *@This(), dyn_lib: os.LoadedLibrary) !void {
+    if (PLATFORM == .windows) {
+        self.getSettings = @ptrCast(os.windows.GetProcAddress(dyn_lib, "getSettings") orelse return error.LookupFail);
+        self.initMinimal = @ptrCast(os.windows.GetProcAddress(dyn_lib, "init") orelse return error.LookupFail);
+        self.initFull2D = @ptrCast(os.windows.GetProcAddress(dyn_lib, "init") orelse return error.LookupFail);
+        self.initFull3D = @ptrCast(os.windows.GetProcAddress(dyn_lib, "init") orelse return error.LookupFail);
 
-    self.deinit = dyn_lib.lookup(@TypeOf(self.deinit), "deinit") orelse return error.LookupFail;
+        self.deinit = @ptrCast(os.windows.GetProcAddress(dyn_lib, "deinit") orelse return error.LookupFail);
 
-    self.willReload = dyn_lib.lookup(@TypeOf(self.willReload), "willReload") orelse return error.LookupFail;
-    self.reloaded = dyn_lib.lookup(@TypeOf(self.reloaded), "reloaded") orelse return error.LookupFail;
+        self.willReload = @ptrCast(os.windows.GetProcAddress(dyn_lib, "willReload") orelse return error.LookupFail);
+        self.reloaded = @ptrCast(os.windows.GetProcAddress(dyn_lib, "reloaded") orelse return error.LookupFail);
 
-    self.processInput = dyn_lib.lookup(@TypeOf(self.processInput), "processInput") orelse return error.LookupFail;
-    self.tick = dyn_lib.lookup(@TypeOf(self.tick), "tick") orelse return error.LookupFail;
-    self.draw = dyn_lib.lookup(@TypeOf(self.draw), "draw") orelse return error.LookupFail;
+        self.processInput = @ptrCast(os.windows.GetProcAddress(dyn_lib, "processInput") orelse return error.LookupFail);
+        self.tick = @ptrCast(os.windows.GetProcAddress(dyn_lib, "tick") orelse return error.LookupFail);
+        self.draw = @ptrCast(os.windows.GetProcAddress(dyn_lib, "draw") orelse return error.LookupFail);
+    } else {
+        self.getSettings = dyn_lib.lookup(@TypeOf(self.getSettings), "getSettings") orelse return error.LookupFail;
+        self.initMinimal = dyn_lib.lookup(@TypeOf(self.initMinimal), "init") orelse return error.LookupFail;
+        self.initFull2D = dyn_lib.lookup(@TypeOf(self.initFull2D), "init") orelse return error.LookupFail;
+        self.initFull3D = dyn_lib.lookup(@TypeOf(self.initFull3D), "init") orelse return error.LookupFail;
+
+        self.deinit = dyn_lib.lookup(@TypeOf(self.deinit), "deinit") orelse return error.LookupFail;
+
+        self.willReload = dyn_lib.lookup(@TypeOf(self.willReload), "willReload") orelse return error.LookupFail;
+        self.reloaded = dyn_lib.lookup(@TypeOf(self.reloaded), "reloaded") orelse return error.LookupFail;
+
+        self.processInput = dyn_lib.lookup(@TypeOf(self.processInput), "processInput") orelse return error.LookupFail;
+        self.tick = dyn_lib.lookup(@TypeOf(self.tick), "tick") orelse return error.LookupFail;
+        self.draw = dyn_lib.lookup(@TypeOf(self.draw), "draw") orelse return error.LookupFail;
+    }
 }

--- a/src/lib/aseprite.zig
+++ b/src/lib/aseprite.zig
@@ -7,8 +7,8 @@ const flint = @import("flint.zig");
 const PLATFORM = @import("builtin").os.tag;
 
 /// Opens an Aseprite document in Aseprite.
-pub fn openInAseprite(sprite_asset: *AsepriteAsset, allocator: std.mem.Allocator) void {
-    if (flint.fs.getFilePathRelative(sprite_asset.path, allocator)) |path| {
+pub fn openInAseprite(sprite_asset: *AsepriteAsset, allocator: std.mem.Allocator, io: std.Io) void {
+    if (flint.fs.getFilePathRelative(io, sprite_asset.path, allocator)) |path| {
         defer allocator.free(path);
 
         const process_args = if (PLATFORM == .windows) [_][]const u8{
@@ -19,8 +19,7 @@ pub fn openInAseprite(sprite_asset: *AsepriteAsset, allocator: std.mem.Allocator
             path,
         };
 
-        var aseprite_process = std.process.Child.init(&process_args, allocator);
-        aseprite_process.spawn() catch |err| {
+        _ = std.process.run(allocator, io, .{ .argv = &process_args }) catch |err| {
             std.log.err("Error spawning process: {t}\n", .{err});
         };
     } else |err| {
@@ -78,12 +77,17 @@ pub const AsepriteAsset = struct {
     }
 
     // Loads an Aseprite document from the specified path and generates SDL textures for each frame.
-    pub fn load(path: []const u8, renderer: *sdl.SDL_Renderer, allocator: std.mem.Allocator) ?AsepriteAsset {
+    pub fn load(
+        path: []const u8,
+        renderer: *sdl.SDL_Renderer,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+    ) ?AsepriteAsset {
         var result: ?AsepriteAsset = null;
 
         std.log.info("Loading AsepriteAsset: {s}", .{path});
 
-        if (loadDocument(path, allocator)) |doc| {
+        if (loadDocument(path, allocator, io)) |doc| {
             var textures: std.ArrayList(*sdl.SDL_Texture) = .empty;
 
             for (doc.frames) |frame| {
@@ -145,14 +149,14 @@ pub const AsepriteAsset = struct {
 };
 
 /// Load an Aseprite document from the specified path relative to CWD, with fallback relative to exe directory.
-pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator) !AseDocument {
+pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator, io: std.Io) !AseDocument {
     var result: AseDocument = undefined;
 
-    const file = try flint.fs.openFileRelative(path, .{ .mode = .read_only });
-    defer file.close();
+    const file = try flint.fs.openFileRelative(io, path, .{ .mode = .read_only });
+    defer file.close(io);
 
     var buf: [1024 * 1024]u8 = undefined;
-    var file_reader = file.reader(&buf);
+    var file_reader = file.reader(io, &buf);
 
     const opt_header: ?*AseHeader = try parseHeader(&file_reader.interface, allocator);
     var frames: std.ArrayList(AseFrame) = .empty;

--- a/src/lib/aseprite.zig
+++ b/src/lib/aseprite.zig
@@ -547,7 +547,8 @@ fn parseTagsChunks(reader: *std.Io.Reader, allocator: std.mem.Allocator) !?[]*As
 }
 
 test "single frame" {
-    const aseprite_doc: ?AseDocument = try loadDocument("fixtures/test.aseprite", std.testing.allocator);
+    const aseprite_doc: ?AseDocument =
+        try loadDocument("fixtures/test.aseprite", std.testing.allocator, std.testing.io);
 
     try std.testing.expect(aseprite_doc != null);
 
@@ -570,7 +571,8 @@ test "single frame" {
 }
 
 test "multiple frames" {
-    const aseprite_doc: ?AseDocument = try loadDocument("fixtures/test_animation.aseprite", std.testing.allocator);
+    const aseprite_doc: ?AseDocument =
+        try loadDocument("fixtures/test_animation.aseprite", std.testing.allocator, std.testing.io);
 
     try std.testing.expect(aseprite_doc != null);
 

--- a/src/lib/aseprite.zig
+++ b/src/lib/aseprite.zig
@@ -11,12 +11,10 @@ pub fn openInAseprite(sprite_asset: *AsepriteAsset, allocator: std.mem.Allocator
     if (flint.fs.getFilePathRelative(io, sprite_asset.path, allocator)) |path| {
         defer allocator.free(path);
 
-        const process_args = if (PLATFORM == .windows) [_][]const u8{
-            "Aseprite.exe",
-            path,
-        } else [_][]const u8{
-            "open",
-            path,
+        const process_args = switch (PLATFORM) {
+            .windows => [_][]const u8{ "Aseprite.exe", path },
+            .macos => [_][]const u8{ "open", path },
+            else => [_][]const u8{ "aseprite", path },
         };
 
         _ = std.process.spawn(io, .{ .argv = &process_args }) catch |err| {

--- a/src/lib/aseprite.zig
+++ b/src/lib/aseprite.zig
@@ -19,7 +19,7 @@ pub fn openInAseprite(sprite_asset: *AsepriteAsset, allocator: std.mem.Allocator
             path,
         };
 
-        _ = std.process.run(allocator, io, .{ .argv = &process_args }) catch |err| {
+        _ = std.process.spawn(io, .{ .argv = &process_args }) catch |err| {
             std.log.err("Error spawning process: {t}\n", .{err});
         };
     } else |err| {

--- a/src/lib/docs.zig
+++ b/src/lib/docs.zig
@@ -66,6 +66,7 @@
 //! * See `src/examples/template/build.zig` for a complete example.
 pub const sdl = @import("sdl.zig");
 pub const fs = @import("fs.zig");
+pub const os = @import("os.zig");
 pub const aseprite = @import("aseprite.zig");
 pub const imgui = @import("imgui.zig");
 pub const internal = @import("internal.zig");

--- a/src/lib/flint.zig
+++ b/src/lib/flint.zig
@@ -3,6 +3,7 @@ const INTERNAL: bool = @import("build_options").internal;
 pub const sdl = @import("sdl.zig");
 pub const aseprite = @import("aseprite.zig");
 pub const fs = @import("fs.zig");
+pub const os = @import("os.zig");
 pub const imgui = if (INTERNAL) @import("imgui.zig") else struct {
     pub const ImGuiContext: type = anyopaque;
 };

--- a/src/lib/fs.zig
+++ b/src/lib/fs.zig
@@ -3,54 +3,57 @@ const std = @import("std");
 
 /// Opens a directory relative to the current working directory.
 /// Falls back to the executable directory if the directory isn't found.
-pub fn openDirRelative(sub_path: []const u8, args: std.fs.Dir.OpenOptions) !std.fs.Dir {
-    if (std.fs.cwd().openDir(sub_path, args)) |directory| {
+pub fn openDirRelative(io: std.Io, sub_path: []const u8, args: std.Io.Dir.OpenOptions) !std.Io.Dir {
+    if (std.Io.Dir.cwd().openDir(io, sub_path, args)) |directory| {
         return directory;
     } else |_| {
         var buffer: [1024]u8 = undefined;
-        const exe_path = try std.fs.selfExeDirPath(&buffer);
+        const path_length = try std.process.executableDirPath(io, &buffer);
+        const exe_path = buffer[0..path_length];
 
-        var exe_dir = try std.fs.cwd().openDir(exe_path, .{});
-        defer exe_dir.close();
+        var exe_dir = try std.Io.Dir.cwd().openDir(io, exe_path, .{});
+        defer exe_dir.close(io);
 
-        return try exe_dir.openDir(sub_path, args);
+        return try exe_dir.openDir(io, sub_path, args);
     }
 }
 
 /// Opens a file relative to the current working directory.
 /// Falls back to the executable directory if the file isn't found.
-pub fn openFileRelative(sub_path: []const u8, flags: std.fs.File.OpenFlags) !std.fs.File {
-    if (std.fs.cwd().openFile(sub_path, flags)) |file| {
+pub fn openFileRelative(io: std.Io, sub_path: []const u8, flags: std.Io.File.OpenFlags) !std.Io.File {
+    if (std.Io.Dir.cwd().openFile(io, sub_path, flags)) |file| {
         return file;
     } else |_| {
         var buffer: [1024]u8 = undefined;
-        const exe_path = try std.fs.selfExeDirPath(&buffer);
+        const path_length = try std.process.executableDirPath(io, &buffer);
+        const exe_path = buffer[0..path_length];
 
-        var exe_dir = try std.fs.cwd().openDir(exe_path, .{});
-        defer exe_dir.close();
+        var exe_dir = try std.Io.Dir.cwd().openDir(io, exe_path, .{});
+        defer exe_dir.close(io);
 
-        return try exe_dir.openFile(sub_path, flags);
+        return try exe_dir.openFile(io, sub_path, flags);
     }
 }
 
 /// Returns the provided path if it exists relative to the current working directory, otherwise it returns the path
 /// relative to the executable directory. Allocates memory for the result, which must be freed by the caller.
-pub fn getFilePathRelative(sub_path: []const u8, allocator: std.mem.Allocator) ![]const u8 {
-    if (fileExists(sub_path)) {
+pub fn getFilePathRelative(io: std.Io, sub_path: []const u8, allocator: std.mem.Allocator) ![]const u8 {
+    if (fileExists(io, sub_path)) {
         return try std.fmt.allocPrint(allocator, "{s}", .{sub_path});
     } else {
         var buffer: [1024]u8 = undefined;
-        const exe_path = try std.fs.selfExeDirPath(&buffer);
+        const path_length = try std.process.executableDirPath(io, &buffer);
+        const exe_path = buffer[0..path_length];
         return try std.fs.path.join(allocator, &.{ exe_path, sub_path });
     }
 }
 
 /// Checks if a file exists.
-pub fn fileExists(file_name: []const u8) bool {
+pub fn fileExists(io: std.Io, file_name: []const u8) bool {
     var result: bool = false;
 
-    const opt_file: ?std.fs.File = std.fs.cwd().openFile(file_name, .{ .mode = .read_only }) catch null;
-    defer if (opt_file) |file| file.close();
+    const opt_file: ?std.Io.File = std.Io.Dir.cwd().openFile(io, file_name, .{ .mode = .read_only }) catch null;
+    defer if (opt_file) |file| file.close(io);
 
     if (opt_file != null) {
         result = true;

--- a/src/lib/internal.zig
+++ b/src/lib/internal.zig
@@ -348,8 +348,9 @@ pub const DebugOutputWindow = struct {
             },
             .vector => |vector_info| {
                 try writer.print("{{", .{});
-                for (0..vector_info.len) |i| {
-                    try writer.print("{d}", .{value[i]});
+                const array: [vector_info.len]vector_info.child = value;
+                for (&array, 0..) |elem, i| {
+                    try writer.print("{d}", .{elem});
 
                     if (i < vector_info.len - 1) {
                         try writer.print(", ", .{});

--- a/src/lib/internal.zig
+++ b/src/lib/internal.zig
@@ -445,7 +445,7 @@ pub const handleCustomTypesFn = ?*const fn (
 /// Generates imgui inputs for all fields on a struct.
 pub fn inspectStruct(
     struct_ptr: anytype,
-    ignored_fields: []const []const u8,
+    comptime ignored_fields: []const []const u8,
     expand_sections: bool,
     /// Function pointer which allows you to handle specific fields manually, see `handleCustomTypesFn`.
     comptime optHandleCustomTypes: handleCustomTypesFn,
@@ -464,7 +464,7 @@ pub fn inspectStruct(
 
 fn inspectStructInternal(
     struct_ptr: anytype,
-    ignored_fields: []const []const u8,
+    comptime ignored_fields: []const []const u8,
     expand_sections: bool,
     comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {
@@ -472,11 +472,13 @@ fn inspectStructInternal(
     switch (struct_info) {
         .@"struct" => {
             inline for (struct_info.@"struct".fields) |struct_field| {
-                var skip_field = false;
-                for (ignored_fields) |ignored| {
-                    if (std.mem.eql(u8, ignored, struct_field.name)) {
-                        skip_field = true;
-                        break;
+                comptime var skip_field = false;
+                comptime {
+                    for (ignored_fields) |ignored| {
+                        if (std.mem.eql(u8, ignored, struct_field.name)) {
+                            skip_field = true;
+                            break;
+                        }
                     }
                 }
 
@@ -517,7 +519,7 @@ fn inspectStructInternal(
 fn inputStruct(
     struct_field: std.builtin.Type.StructField,
     field_ptr: anytype,
-    ignored_fields: []const []const u8,
+    comptime ignored_fields: []const []const u8,
     expand_sections: bool,
     comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {
@@ -618,7 +620,7 @@ fn inputStruct(
 fn inputStructSection(
     target: anytype,
     heading: ?[*:0]const u8,
-    ignored_fields: []const []const u8,
+    comptime ignored_fields: []const []const u8,
     expand_sections: bool,
     comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {

--- a/src/lib/internal.zig
+++ b/src/lib/internal.zig
@@ -448,7 +448,7 @@ pub fn inspectStruct(
     ignored_fields: []const []const u8,
     expand_sections: bool,
     /// Function pointer which allows you to handle specific fields manually, see `handleCustomTypesFn`.
-    optHandleCustomTypes: handleCustomTypesFn,
+    comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {
     switch (@typeInfo(@TypeOf(struct_ptr))) {
         .optional => {
@@ -466,7 +466,7 @@ fn inspectStructInternal(
     struct_ptr: anytype,
     ignored_fields: []const []const u8,
     expand_sections: bool,
-    optHandleCustomTypes: handleCustomTypesFn,
+    comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {
     const struct_info = @typeInfo(@TypeOf(struct_ptr.*));
     switch (struct_info) {
@@ -519,7 +519,7 @@ fn inputStruct(
     field_ptr: anytype,
     ignored_fields: []const []const u8,
     expand_sections: bool,
-    optHandleCustomTypes: handleCustomTypesFn,
+    comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {
     var handled: bool = false;
     if (optHandleCustomTypes) |handleCustomTypes| {
@@ -620,7 +620,7 @@ fn inputStructSection(
     heading: ?[*:0]const u8,
     ignored_fields: []const []const u8,
     expand_sections: bool,
-    optHandleCustomTypes: handleCustomTypesFn,
+    comptime optHandleCustomTypes: handleCustomTypesFn,
 ) void {
     imgui.ImGui_PushIDPtr(@ptrCast(heading));
     defer imgui.ImGui_PopID();

--- a/src/lib/os.zig
+++ b/src/lib/os.zig
@@ -23,9 +23,9 @@ pub fn loadLibrary(path: []const u8, allocator: std.mem.Allocator) !?LoadedLibra
 }
 
 /// A wrapper which uses kernel32 on Windows and the standard library on other platforms.
-pub fn unloadLibrary(library: LoadedLibrary) void {
+pub fn unloadLibrary(library: *LoadedLibrary) void {
     if (PLATFORM == .windows) {
-        _ = windows.FreeLibrary(library);
+        _ = windows.FreeLibrary(library.*);
     } else {
         library.close();
     }

--- a/src/lib/os.zig
+++ b/src/lib/os.zig
@@ -1,0 +1,32 @@
+//! Exposes platform specific functionality.
+const std = @import("std");
+
+pub const windows = @import("os/windows.zig");
+
+// Build options.
+const PLATFORM = @import("builtin").os.tag;
+
+pub const LoadedLibrary = if (PLATFORM == .windows) windows.HMODULE else std.DynLib;
+
+/// A wrapper which uses kernel32 on Windows and the standard library on other platforms.
+pub fn loadLibrary(path: []const u8, allocator: std.mem.Allocator) !?LoadedLibrary {
+    var result: ?LoadedLibrary = null;
+    if (PLATFORM == .windows) {
+        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(allocator, path);
+        defer allocator.free(path_w);
+
+        result = windows.LoadLibraryExW(path_w, null, 0);
+    } else {
+        result = try std.DynLib.open(path);
+    }
+    return result;
+}
+
+/// A wrapper which uses kernel32 on Windows and the standard library on other platforms.
+pub fn unloadLibrary(library: LoadedLibrary) void {
+    if (PLATFORM == .windows) {
+        _ = windows.FreeLibrary(library);
+    } else {
+        library.close();
+    }
+}

--- a/src/lib/os/windows.zig
+++ b/src/lib/os/windows.zig
@@ -1,0 +1,25 @@
+//! Exposes Windows specific functionality.
+pub const BOOL = c_int;
+pub const CHAR = u8;
+pub const WCHAR = u16;
+pub const DWORD = u32;
+pub const HANDLE = *anyopaque;
+pub const HMODULE = *opaque {};
+pub const FARPROC = *opaque {};
+pub const LPCWSTR = [*:0]const WCHAR;
+pub const LPCSTR = [*:0]const CHAR;
+
+pub extern "kernel32" fn LoadLibraryExW(
+    lpLibFileName: LPCWSTR,
+    hFile: ?HANDLE,
+    dwFlags: DWORD,
+) callconv(.winapi) ?HMODULE;
+
+pub extern "kernel32" fn GetProcAddress(
+    hModule: HMODULE,
+    lpProcName: LPCSTR,
+) callconv(.winapi) ?FARPROC;
+
+pub extern "kernel32" fn FreeLibrary(
+    hModule: HMODULE,
+) callconv(.winapi) BOOL;

--- a/src/main.zig
+++ b/src/main.zig
@@ -355,16 +355,16 @@ fn loadDll(io: std.Io, allocator: std.mem.Allocator) !void {
     var lib_path: []const u8 = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ LIB_DEV_DIRECTORY, lib_name });
 
     // Try to load the game library from the dev directory first.
-    opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
+    opt_dyn_lib = flint.os.loadLibrary(lib_path, allocator) catch null;
 
     if (opt_dyn_lib == null) {
         lib_path = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ "./", lib_name });
-        opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
+        opt_dyn_lib = flint.os.loadLibrary(lib_path, allocator) catch null;
     }
 
     if (opt_dyn_lib == null) {
         lib_path = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ "./lib/", lib_name });
-        opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
+        opt_dyn_lib = flint.os.loadLibrary(lib_path, allocator) catch null;
     }
 
     if (opt_dyn_lib) |*dyn_lib| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -29,8 +29,7 @@ var assets_last_modified: i128 = 0;
 var code_last_modified: i128 = 0;
 
 pub fn main(init: std.process.Init) !void {
-    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
-    const allocator = debug_allocator.allocator();
+    const allocator = init.gpa;
 
     loadDll(init.io, allocator) catch |err| {
         std.log.err("Failed to load the game library. Error: {t}", .{err});
@@ -254,10 +253,6 @@ pub fn main(init: std.process.Init) !void {
 
     sdl.SDL_DestroyWindow(window);
     sdl.SDL_Quit();
-
-    if (INTERNAL) {
-        _ = debug_allocator.detectLeaks();
-    }
 }
 
 fn initImgui(

--- a/src/main.zig
+++ b/src/main.zig
@@ -292,6 +292,8 @@ fn initChangeTimes(allocator: std.mem.Allocator, io: std.Io) void {
 fn dllHasChanged(io: std.Io) bool {
     var result = false;
     const stat = std.Io.Dir.cwd().statFile(io, LIB_DEV_DIRECTORY ++ LIB_NAME, .{}) catch return false;
+    if (stat.mtime.nanoseconds > dyn_lib_last_modified) {
+        dyn_lib_last_modified = stat.mtime.nanoseconds;
         result = true;
     }
     return result;
@@ -317,6 +319,8 @@ fn checkForChangesInDirectory(allocator: std.mem.Allocator, io: std.Io, path: []
     while (try walker.next(io)) |entry| {
         if (entry.kind == .file) {
             const stat = try directory.statFile(io, entry.path, .{});
+            if (stat.mtime.nanoseconds > last_change.*) {
+                last_change.* = stat.mtime.nanoseconds;
                 result = true;
                 break;
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,7 +21,7 @@ const WINDOW_DECORATIONS_WIDTH = if (PLATFORM == .windows) 0 else 0;
 const WINDOW_DECORATIONS_HEIGHT = if (PLATFORM == .windows) 31 else 0;
 
 var game: GameLib = .{};
-var opt_dyn_lib: ?std.DynLib = null;
+var opt_dyn_lib: ?flint.os.LoadedLibrary = null;
 var build_process: ?std.process.Child = null;
 var dyn_lib_last_modified: i128 = 0;
 var src_last_modified: i128 = 0;
@@ -32,7 +32,7 @@ pub fn main(init: std.process.Init) !void {
     var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
     const allocator = debug_allocator.allocator();
 
-    loadDll(init.io) catch |err| {
+    loadDll(init.io, allocator) catch |err| {
         std.log.err("Failed to load the game library. Error: {t}", .{err});
         return err;
     };
@@ -198,7 +198,7 @@ pub fn main(init: std.process.Init) !void {
                     }
 
                     unloadDll() catch unreachable;
-                    loadDll(init.io) catch @panic("Failed to load the game lib.");
+                    loadDll(init.io, allocator) catch @panic("Failed to load the game lib.");
 
                     if (manage_imgui_lifecycle) {
                         initImgui(window.?, game_renderer, game_gpu_device, game_settings);
@@ -332,14 +332,14 @@ fn checkForChangesInDirectory(allocator: std.mem.Allocator, io: std.Io, path: []
 
 fn unloadDll() !void {
     if (opt_dyn_lib) |*dyn_lib| {
-        dyn_lib.close();
+        flint.os.unloadLibrary(dyn_lib.*);
         opt_dyn_lib = null;
     } else {
         return error.AlreadyUnloaded;
     }
 }
 
-fn loadDll(io: std.Io) !void {
+fn loadDll(io: std.Io, allocator: std.mem.Allocator) !void {
     if (opt_dyn_lib != null) return error.AlreadyLoaded;
 
     var lib_name: []const u8 = LIB_NAME;
@@ -350,8 +350,8 @@ fn loadDll(io: std.Io) !void {
         // Only make a copy of the library if we are in the dev directory (zig-out/bin/ on Windows).
         if (flint.fs.fileExists(io, LIB_DEV_DIRECTORY ++ LIB_NAME)) {
             const temp_copy_name: []const u8 = LIB_BASE_NAME ++ "_temp.dll";
-            var dev_directory = try std.fs.cwd().openDir(LIB_DEV_DIRECTORY, .{});
-            try dev_directory.copyFile(LIB_NAME, dev_directory, temp_copy_name, .{});
+            var dev_directory = try std.Io.Dir.cwd().openDir(io, LIB_DEV_DIRECTORY, .{});
+            try dev_directory.copyFile(LIB_NAME, dev_directory, temp_copy_name, io, .{});
             lib_name = temp_copy_name;
         }
     }
@@ -359,31 +359,21 @@ fn loadDll(io: std.Io) !void {
     var buffer: [1024]u8 = undefined;
     var lib_path: []const u8 = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ LIB_DEV_DIRECTORY, lib_name });
 
-    // Try to load the game library from the dev directory.
-    opt_dyn_lib = std.DynLib.open(lib_path) catch null;
-    if (opt_dyn_lib != null) {
-        std.log.info("Loading game library ({s}).", .{lib_path});
-    }
+    // Try to load the game library from the dev directory first.
+    opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
 
     if (opt_dyn_lib == null) {
-        // Try to load the game library from the current working directory.
         lib_path = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ "./", lib_name });
-        opt_dyn_lib = std.DynLib.open(lib_path) catch null;
-        if (opt_dyn_lib != null) {
-            std.log.info("Loading game library ({s}).", .{lib_path});
-        }
+        opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
     }
 
     if (opt_dyn_lib == null) {
-        // Try to load the game library from the "lib" directory in the current working directory.
         lib_path = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ "./lib/", lib_name });
-        opt_dyn_lib = std.DynLib.open(lib_path) catch null;
-        if (opt_dyn_lib != null) {
-            std.log.info("Loading game library ({s}).", .{lib_path});
-        }
+        opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
     }
 
-    if (opt_dyn_lib) |*dyn_lib| {
+    if (opt_dyn_lib) |dyn_lib| {
+        std.log.info("Loading game library ({s}).", .{lib_path});
         try game.load(dyn_lib);
     } else {
         return error.LibraryNotFound;

--- a/src/main.zig
+++ b/src/main.zig
@@ -327,7 +327,7 @@ fn checkForChangesInDirectory(allocator: std.mem.Allocator, io: std.Io, path: []
 
 fn unloadDll() !void {
     if (opt_dyn_lib) |*dyn_lib| {
-        flint.os.unloadLibrary(dyn_lib.*);
+        flint.os.unloadLibrary(dyn_lib);
         opt_dyn_lib = null;
     } else {
         return error.AlreadyUnloaded;
@@ -367,7 +367,7 @@ fn loadDll(io: std.Io, allocator: std.mem.Allocator) !void {
         opt_dyn_lib = try flint.os.loadLibrary(lib_path, allocator);
     }
 
-    if (opt_dyn_lib) |dyn_lib| {
+    if (opt_dyn_lib) |*dyn_lib| {
         std.log.info("Loading game library ({s}).", .{lib_path});
         try game.load(dyn_lib);
     } else {

--- a/src/main.zig
+++ b/src/main.zig
@@ -38,7 +38,7 @@ pub fn main(init: std.process.Init) !void {
     };
 
     const game_settings: GameLib.Settings = game.getSettings();
-    const target_frame_time: u64 = @intFromFloat(1000 / @as(f32, @floatFromInt(game_settings.target_frame_rate)));
+    const target_frame_time: u64 = @trunc(1000 / @as(f32, @floatFromInt(game_settings.target_frame_rate)));
 
     if (!sdl.SDL_Init(sdl.SDL_INIT_VIDEO | sdl.SDL_INIT_EVENTS)) {
         @panic("SDL_Init failed.");

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,11 +28,11 @@ var src_last_modified: i128 = 0;
 var assets_last_modified: i128 = 0;
 var code_last_modified: i128 = 0;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
     const allocator = debug_allocator.allocator();
 
-    loadDll() catch |err| {
+    loadDll(init.io) catch |err| {
         std.log.err("Failed to load the game library. Error: {t}", .{err});
         return err;
     };
@@ -147,6 +147,7 @@ pub fn main() !void {
         .Full2D => {
             const dependencies: GameLib.Dependencies.Full2D = .{
                 .allocator = &game_allocator,
+                .io = &init.io,
                 .window = window.?,
                 .renderer = game_renderer.?,
                 .internal = internal_dependencies,
@@ -157,6 +158,7 @@ pub fn main() !void {
         .Full3D => {
             const dependencies: GameLib.Dependencies.Full3D = .{
                 .allocator = &game_allocator,
+                .io = &init.io,
                 .window = window.?,
                 .gpu_device = game_gpu_device.?,
                 .internal = internal_dependencies,
@@ -167,7 +169,7 @@ pub fn main() !void {
     }
 
     if (INTERNAL) {
-        initChangeTimes(allocator);
+        initChangeTimes(allocator, init.io);
     }
 
     var previous_frame_start_time: u64 = 0;
@@ -178,14 +180,13 @@ pub fn main() !void {
         const delta_time = frame_start_time - previous_frame_start_time;
 
         if (INTERNAL) {
-            const assets_changed = assetsHaveChanged(allocator);
-            const code_changed = codeHasChanged(allocator);
-            const dll_changed = dllHasChanged();
+            const assets_changed = assetsHaveChanged(allocator, init.io);
+            const code_changed = codeHasChanged(allocator, init.io);
+            const dll_changed = dllHasChanged(init.io);
 
             if (code_changed) {
                 std.log.info("Code changed, rebuilding game library...", .{});
-                var zig_build_process = std.process.Child.init(&.{ "zig", "build", "-Dlib_only" }, allocator);
-                _ = try zig_build_process.spawn();
+                _ = try std.process.run(allocator, init.io, .{ .argv = &.{ "zig", "build", "-Dlib_only" } });
             }
 
             if (dll_changed or assets_changed) {
@@ -197,7 +198,7 @@ pub fn main() !void {
                     }
 
                     unloadDll() catch unreachable;
-                    loadDll() catch @panic("Failed to load the game lib.");
+                    loadDll(init.io) catch @panic("Failed to load the game lib.");
 
                     if (manage_imgui_lifecycle) {
                         initImgui(window.?, game_renderer, game_gpu_device, game_settings);
@@ -207,7 +208,7 @@ pub fn main() !void {
                 // TODO: This is a workaround for a bug that happens when dealing with large Aseprite files where the
                 // file is incomplete when read too soon after saving changes to it. This may need to be tuned to
                 // handle bigger files, and would be more robust if we could know when the file was ready for reading.
-                std.Thread.sleep(10_000_000);
+                try std.Io.sleep(init.io, .fromMilliseconds(10), .awake);
 
                 game.reloaded(state, imgui.context);
             }
@@ -282,44 +283,40 @@ fn initImgui(
     }
 }
 
-fn initChangeTimes(allocator: std.mem.Allocator) void {
-    _ = dllHasChanged();
-    _ = assetsHaveChanged(allocator);
-    _ = codeHasChanged(allocator);
+fn initChangeTimes(allocator: std.mem.Allocator, io: std.Io) void {
+    _ = dllHasChanged(io);
+    _ = assetsHaveChanged(allocator, io);
+    _ = codeHasChanged(allocator, io);
 }
 
-fn dllHasChanged() bool {
+fn dllHasChanged(io: std.Io) bool {
     var result = false;
-    const stat = std.fs.cwd().statFile(LIB_DEV_DIRECTORY ++ LIB_NAME) catch return false;
-    if (stat.mtime > dyn_lib_last_modified) {
-        dyn_lib_last_modified = stat.mtime;
+    const stat = std.Io.Dir.cwd().statFile(io, LIB_DEV_DIRECTORY ++ LIB_NAME, .{}) catch return false;
         result = true;
     }
     return result;
 }
 
-fn assetsHaveChanged(allocator: std.mem.Allocator) bool {
-    return checkForChangesInDirectory(allocator, "assets", &assets_last_modified) catch false;
+fn assetsHaveChanged(allocator: std.mem.Allocator, io: std.Io) bool {
+    return checkForChangesInDirectory(allocator, io, "assets", &assets_last_modified) catch false;
 }
 
-fn codeHasChanged(allocator: std.mem.Allocator) bool {
-    return checkForChangesInDirectory(allocator, "src", &code_last_modified) catch false;
+fn codeHasChanged(allocator: std.mem.Allocator, io: std.Io) bool {
+    return checkForChangesInDirectory(allocator, io, "src", &code_last_modified) catch false;
 }
 
-fn checkForChangesInDirectory(allocator: std.mem.Allocator, path: []const u8, last_change: *i128) !bool {
+fn checkForChangesInDirectory(allocator: std.mem.Allocator, io: std.Io, path: []const u8, last_change: *i128) !bool {
     var result = false;
 
-    var directory = try flint.fs.openDirRelative(path, .{ .access_sub_paths = true, .iterate = true });
-    defer directory.close();
+    var directory = try flint.fs.openDirRelative(io, path, .{ .access_sub_paths = true, .iterate = true });
+    defer directory.close(io);
 
     var walker = try directory.walk(allocator);
     defer walker.deinit();
 
-    while (try walker.next()) |entry| {
+    while (try walker.next(io)) |entry| {
         if (entry.kind == .file) {
-            const stat = try directory.statFile(entry.path);
-            if (stat.mtime > last_change.*) {
-                last_change.* = stat.mtime;
+            const stat = try directory.statFile(io, entry.path, .{});
                 result = true;
                 break;
             }
@@ -338,7 +335,7 @@ fn unloadDll() !void {
     }
 }
 
-fn loadDll() !void {
+fn loadDll(io: std.Io) !void {
     if (opt_dyn_lib != null) return error.AlreadyLoaded;
 
     var lib_name: []const u8 = LIB_NAME;
@@ -347,7 +344,7 @@ fn loadDll() !void {
     // otherwise the zig build wouldn't be allowed to overwrite the .dll file.
     if (INTERNAL and PLATFORM == .windows) {
         // Only make a copy of the library if we are in the dev directory (zig-out/bin/ on Windows).
-        if (flint.fs.fileExists(LIB_DEV_DIRECTORY ++ LIB_NAME)) {
+        if (flint.fs.fileExists(io, LIB_DEV_DIRECTORY ++ LIB_NAME)) {
             const temp_copy_name: []const u8 = LIB_BASE_NAME ++ "_temp.dll";
             var dev_directory = try std.fs.cwd().openDir(LIB_DEV_DIRECTORY, .{});
             try dev_directory.copyFile(LIB_NAME, dev_directory, temp_copy_name, .{});


### PR DESCRIPTION
# Update to zig version 0.16.0.

Todo:
- [x] Refactor all file operations to use `std.Io`.
- [x] Figure out what is causing the `inputBool` call in `inspectStruct` to have an unexpected alignment of `align(8:0:8)`.
- [x] Fix OutOfMemory error when double-clicking on sprites in Diamonds example.
- [x] Wait for Zig 0.16.0 to actually be released.
- [x] Update Zig version used in CI.
- [x] Refactor how we DLLs on Windows now that `std.DynLib` no longer supports Windows.
- [x] Do we still need a custom log function for in GameLib.zig? Not anymore.
- [x] Test on Linux.
- [x] Test on Windows.