### PR TITLE
Make executable more portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is roughly speaking 0.MAJOR.MINOR.PATCH.
 * Updated SDL to version 3.4.4.
 * Changed where we look for the game library to make the executable more portable. The order is now: zig-out if internal build, same directory as executable, and finally a directory called "lib" in the same directory as the executable.
 * The workaround to deal with building the game library while it is open on Windows is now only applied if the library is found in the dev directory (zig-out/bin), otherwise we skip it. This allows internal builds to be portable.
+* Changed where we look for assets to make the executable more portable. Previously the asset paths only worked relative to the current working directory, now we have a fallback which looks relative to the executable directory if not found in the current directory.
 ### Fixed
 * Fixed installation of the SDL library artifact when using `linkSDL`. That function now needs the client_b so it can install SDL in the right location.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is roughly speaking 0.MAJOR.MINOR.PATCH.
 * Added RPath entries to Linux/Mac builds so the executable can find libraries in the executable directory and in ./lib. This allows for packaging the executable with the libraries. On Windows it will follow the normal DLL search order, so it's easiest to place the libraries in the same directory as the executable.
 ### Changed
 * Updated SDL to version 3.4.4.
+* Changed where we look for the game library to make the executable more portable. The order is now: zig-out if internal build, same directory as executable, and finally a directory called "lib" in the same directory as the executable.
+* The workaround to deal with building the game library while it is open on Windows is now only applied if the library is found in the dev directory (zig-out/bin), otherwise we skip it. This allows internal builds to be portable.
 ### Fixed
 * Fixed installation of the SDL library artifact when using `linkSDL`. That function now needs the client_b so it can install SDL in the right location.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is roughly speaking 0.MAJOR.MINOR.PATCH.
 ## [Unreleased]
 ### Added
 * Added RPath entries to Linux/Mac builds so the executable can find libraries in the executable directory and in ./lib. This allows for packaging the executable with the libraries. On Windows it will follow the normal DLL search order, so it's easiest to place the libraries in the same directory as the executable.
+* Added a module with utilities for dealing with the file system, to begin with it covers Flints own needs.
 ### Changed
 * Updated SDL to version 3.4.4.
 * Changed where we look for the game library to make the executable more portable. The order is now: zig-out if internal build, same directory as executable, and finally a directory called "lib" in the same directory as the executable.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,19 @@ zig fetch --save git+https://github.com/zoeesilcock/flint.git#v0.10.0
 * internal - exposes tools used to generate editors and tools for internal builds.
 * aseprite - exposes the aseprite importer.
 
-
 ### Hot reloading
 Both the code and the assets automatically update in-game when modified. For code this is achieved by having the entire game code inside a shared library with a thin executable that takes care of reloading the shared library when it changes. When Flint detects a change in the code it triggers `zig build -Dlib_only`. When it detects a change in the dynamic library it loads the new one, making it fully automated. For assets the executable lets the game know when assets have changed so that it can react to that in whatever way that makes sense, the examples reload the assets which shows changes instantly without interrupting the game.
+
+### Packaging
+Building and packaging for release is a broad topic and works differently on each platform. Flint doesn't provide an automated way to do this yet, so it has to be done manually. The executable looks for the game library and assets in a few different places to help make it portable.
+
+#### Asset search paths
+Asset paths default to being relative to the current working directory, if not found there it will try relative to the directory of the executable. This allows the assets to be in the root directory of the project during development and in the same directory as the executable for release. Internal builds support hot reloading of assets even when the executable is not in the development environment, so it's possible to share an internal build with an artist to work on the assets. We might consider baking the assets into the library for release builds in the future.
+
+#### Library search paths
+In development mode it defaults to looking for the library in zig-out (zig-out/bin on Windows and zig-out/lib otherwise). If it fails to find the game library it will look in the same directory as the executable as well as in `./lib` relative to the executable. This allows using the default output locations while developing and then a couple of options when packaging for release.
+
+For other libraries like SDL, the executable looks in the same directory as the executable and in `./lib` relative to the executable. Windows is an exception here as it has its own [search order](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order) for DLLs. The simplest approach is to place the SDL library in the same directory as the executable.
 
 
 ## Examples

--- a/examples/diamonds/src/root.zig
+++ b/examples/diamonds/src/root.zig
@@ -903,7 +903,7 @@ fn unloadLevel(state: *State) void {
 pub fn loadLevel(state: *State, name: []const u8) !void {
     var buf: [LEVEL_NAME_BUFFER_SIZE * 2]u8 = undefined;
     const path = try std.fmt.bufPrint(&buf, "assets/{s}.lvl", .{name});
-    const file = try std.fs.cwd().openFile(path, .{ .mode = .read_only });
+    const file = try flint.fs.openFileRelative(path, .{ .mode = .read_only });
 
     var reader_buf: [10 * 1024]u8 = undefined;
     var file_reader = file.reader(&reader_buf);

--- a/src/lib/aseprite.zig
+++ b/src/lib/aseprite.zig
@@ -74,14 +74,9 @@ pub const AsepriteAsset = struct {
     pub fn load(path: []const u8, renderer: *sdl.SDL_Renderer, allocator: std.mem.Allocator) ?AsepriteAsset {
         var result: ?AsepriteAsset = null;
 
-        std.log.info("loadSprite: {s}", .{path});
+        std.log.info("Loading AsepriteAsset: {s}", .{path});
 
-        const opt_doc = loadDocument(path, allocator) catch |err| blk: {
-            std.log.err("Asperite loadDocument failed: {t}", .{err});
-            break :blk null;
-        };
-
-        if (opt_doc) |doc| {
+        if (loadDocument(path, allocator)) |doc| {
             var textures: std.ArrayList(*sdl.SDL_Texture) = .empty;
 
             for (doc.frames) |frame| {
@@ -127,99 +122,123 @@ pub const AsepriteAsset = struct {
                 textures.append(allocator, texture.?) catch undefined;
             }
 
-            std.log.info("loadSprite: {s}: {d}", .{ path, doc.frames.len });
+            std.log.info("Loaded AsepriteAsset: {s}, frame count: {d}", .{ path, doc.frames.len });
 
             result = AsepriteAsset{
                 .path = path,
                 .document = doc,
                 .frames = textures.toOwnedSlice(allocator) catch &.{},
             };
-        } else {
-            @panic("aseprite.loadDocument failed");
+        } else |err| {
+            std.log.err("Failed to load AsepriteAsset: {t}", .{err});
         }
 
         return result;
     }
 };
 
-/// Load an Aseprite document from the specified path.
-pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator) !?AseDocument {
-    var result: ?AseDocument = null;
+/// Load an Aseprite document from the specified path relative to CWD, with fallback relative to exe directory.
+pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator) !AseDocument {
+    var result: AseDocument = undefined;
 
-    if (std.fs.cwd().openFile(path, .{ .mode = .read_only })) |file| {
-        defer file.close();
+    // Default to opening the file based on the current working directory.
+    var opt_file: ?std.fs.File = std.fs.cwd().openFile(path, .{ .mode = .read_only }) catch null;
 
-        var buf: [1024 * 1024]u8 = undefined;
-        var file_reader = file.reader(&buf);
+    if (opt_file == null) {
+        var buffer: [1024]u8 = undefined;
+        const exe_path = try std.fs.selfExeDirPath(&buffer);
 
-        const opt_header: ?*AseHeader = try parseHeader(&file_reader.interface, allocator);
-        var frames: std.ArrayList(AseFrame) = .empty;
-        defer frames.deinit(allocator);
+        var exe_dir = try std.fs.cwd().openDir(exe_path, .{});
+        defer exe_dir.close();
 
-        std.log.info("loadDocument: {s}", .{path});
+        // If the file wasn't found in the current working directory, look in the exe directory instead.
+        opt_file = exe_dir.openFile(path, .{ .mode = .read_only }) catch |err| switch (err) {
+            error.FileNotFound => {
+                std.log.err("Cannot find Aseprite file, tried at '{s}' and at '{s}/{s}': {t}", .{
+                    path,
+                    exe_path,
+                    path,
+                    err,
+                });
+                return err;
+            },
+            else => return err,
+        };
+    }
 
-        if (opt_header) |header| {
-            std.debug.assert(header.magic_number == 0xA5E0);
-            std.log.info("Frame count: {d}", .{header.frames});
+    const file: std.fs.File = opt_file.?;
+    defer file.close();
 
-            for (0..header.frames) |_| {
-                if (try parseFrameHeader(&file_reader.interface, allocator)) |frame_header| {
-                    std.debug.assert(frame_header.magic_number == 0xF1FA);
-                    std.log.info(
-                        "Frame size: {d}, chunks: {d}",
-                        .{ frame_header.byte_count, frame_header.chunkCount() },
-                    );
+    var buf: [1024 * 1024]u8 = undefined;
+    var file_reader = file.reader(&buf);
 
-                    var cel_chunks: std.ArrayList(*AseCelChunk) = .empty;
-                    var opt_tags: ?[]*AseTagsChunk = null;
+    const opt_header: ?*AseHeader = try parseHeader(&file_reader.interface, allocator);
+    var frames: std.ArrayList(AseFrame) = .empty;
+    defer frames.deinit(allocator);
 
-                    for (0..frame_header.chunkCount()) |_| {
-                        if (try parseChunkHeader(&file_reader.interface, allocator)) |chunk_header| {
-                            defer allocator.destroy(chunk_header);
-                            std.log.info(
-                                "Chunk size: {d}, chunk_type: {}",
-                                .{ chunk_header.chunkSize(), chunk_header.chunk_type },
-                            );
+    std.log.info("loadDocument: {s}", .{path});
 
-                            switch (chunk_header.chunk_type) {
-                                .Cel => {
-                                    if (try parseCelChunk(&file_reader.interface, chunk_header, allocator)) |cel_chunk| {
-                                        try cel_chunks.append(allocator, cel_chunk);
-                                    }
-                                },
-                                .Tags => {
-                                    opt_tags = try parseTagsChunks(&file_reader.interface, allocator);
-                                },
-                                else => {
-                                    file_reader.interface.toss(chunk_header.chunkSize());
-                                },
-                            }
+    if (opt_header) |header| {
+        std.debug.assert(header.magic_number == 0xA5E0);
+        std.log.info("Frame count: {d}", .{header.frames});
+
+        for (0..header.frames) |_| {
+            if (try parseFrameHeader(&file_reader.interface, allocator)) |frame_header| {
+                std.debug.assert(frame_header.magic_number == 0xF1FA);
+                std.log.info(
+                    "Frame size: {d}, chunks: {d}",
+                    .{ frame_header.byte_count, frame_header.chunkCount() },
+                );
+
+                var cel_chunks: std.ArrayList(*AseCelChunk) = .empty;
+                var opt_tags: ?[]*AseTagsChunk = null;
+
+                for (0..frame_header.chunkCount()) |_| {
+                    if (try parseChunkHeader(&file_reader.interface, allocator)) |chunk_header| {
+                        defer allocator.destroy(chunk_header);
+                        std.log.info(
+                            "Chunk size: {d}, chunk_type: {}",
+                            .{ chunk_header.chunkSize(), chunk_header.chunk_type },
+                        );
+
+                        switch (chunk_header.chunk_type) {
+                            .Cel => {
+                                if (try parseCelChunk(&file_reader.interface, chunk_header, allocator)) |cel_chunk| {
+                                    try cel_chunks.append(allocator, cel_chunk);
+                                }
+                            },
+                            .Tags => {
+                                opt_tags = try parseTagsChunks(&file_reader.interface, allocator);
+                            },
+                            else => {
+                                file_reader.interface.toss(chunk_header.chunkSize());
+                            },
                         }
                     }
+                }
 
-                    if (cel_chunks.items.len > 0) {
-                        try frames.append(allocator, AseFrame{
-                            .header = frame_header,
-                            .cel_chunks = try cel_chunks.toOwnedSlice(allocator),
-                            .tags = opt_tags orelse &.{},
-                        });
-                    }
+                if (cel_chunks.items.len > 0) {
+                    try frames.append(allocator, AseFrame{
+                        .header = frame_header,
+                        .cel_chunks = try cel_chunks.toOwnedSlice(allocator),
+                        .tags = opt_tags orelse &.{},
+                    });
                 }
             }
-
-            if (frames.items.len > 0) {
-                result = .{
-                    .header = header,
-                    .frames = try frames.toOwnedSlice(allocator),
-                };
-            } else {
-                std.log.err("No frames found in aseprite file.", .{});
-            }
-        } else {
-            std.log.err("Failed to parse aseprite header.", .{});
         }
-    } else |err| {
-        std.log.info("Cannot find file '{s}': {s}", .{ path, @errorName(err) });
+
+        if (frames.items.len > 0) {
+            result = .{
+                .header = header,
+                .frames = try frames.toOwnedSlice(allocator),
+            };
+        } else {
+            std.log.err("No frames found in aseprite file.", .{});
+            return error.NoFrames;
+        }
+    } else {
+        std.log.err("Failed to parse aseprite header.", .{});
+        return error.InvalidHeader;
     }
 
     return result;

--- a/src/lib/aseprite.zig
+++ b/src/lib/aseprite.zig
@@ -2,23 +2,30 @@
 const std = @import("std");
 const sdl = @import("sdl.zig").c;
 const sdl_utils = @import("sdl.zig");
+const flint = @import("flint.zig");
 
 const PLATFORM = @import("builtin").os.tag;
 
 /// Opens an Aseprite document in Aseprite.
 pub fn openInAseprite(sprite_asset: *AsepriteAsset, allocator: std.mem.Allocator) void {
-    const process_args = if (PLATFORM == .windows) [_][]const u8{
-        "Aseprite.exe",
-        sprite_asset.path,
-    } else [_][]const u8{
-        "open",
-        sprite_asset.path,
-    };
+    if (flint.fs.getFilePathRelative(sprite_asset.path, allocator)) |path| {
+        defer allocator.free(path);
 
-    var aseprite_process = std.process.Child.init(&process_args, allocator);
-    aseprite_process.spawn() catch |err| {
-        std.debug.print("Error spawning process: {}\n", .{err});
-    };
+        const process_args = if (PLATFORM == .windows) [_][]const u8{
+            "Aseprite.exe",
+            path,
+        } else [_][]const u8{
+            "open",
+            path,
+        };
+
+        var aseprite_process = std.process.Child.init(&process_args, allocator);
+        aseprite_process.spawn() catch |err| {
+            std.log.err("Error spawning process: {t}\n", .{err});
+        };
+    } else |err| {
+        std.log.info("Error creating path to AsepriteAsset: {t}\n", .{err});
+    }
 }
 
 /// All data and metadata contained in an Aseprite document.
@@ -141,32 +148,7 @@ pub const AsepriteAsset = struct {
 pub fn loadDocument(path: []const u8, allocator: std.mem.Allocator) !AseDocument {
     var result: AseDocument = undefined;
 
-    // Default to opening the file based on the current working directory.
-    var opt_file: ?std.fs.File = std.fs.cwd().openFile(path, .{ .mode = .read_only }) catch null;
-
-    if (opt_file == null) {
-        var buffer: [1024]u8 = undefined;
-        const exe_path = try std.fs.selfExeDirPath(&buffer);
-
-        var exe_dir = try std.fs.cwd().openDir(exe_path, .{});
-        defer exe_dir.close();
-
-        // If the file wasn't found in the current working directory, look in the exe directory instead.
-        opt_file = exe_dir.openFile(path, .{ .mode = .read_only }) catch |err| switch (err) {
-            error.FileNotFound => {
-                std.log.err("Cannot find Aseprite file, tried at '{s}' and at '{s}/{s}': {t}", .{
-                    path,
-                    exe_path,
-                    path,
-                    err,
-                });
-                return err;
-            },
-            else => return err,
-        };
-    }
-
-    const file: std.fs.File = opt_file.?;
+    const file = try flint.fs.openFileRelative(path, .{ .mode = .read_only });
     defer file.close();
 
     var buf: [1024 * 1024]u8 = undefined;

--- a/src/lib/docs.zig
+++ b/src/lib/docs.zig
@@ -59,8 +59,9 @@
 //!     * **lib_base_name**: a string which decides the name of the dynamic library that the executable will look for.
 //! * See `src/examples/template/build.zig` for a complete example.
 pub const sdl = @import("sdl.zig");
-pub const imgui = @import("imgui.zig");
+pub const fs = @import("fs.zig");
 pub const aseprite = @import("aseprite.zig");
+pub const imgui = @import("imgui.zig");
 pub const internal = @import("internal.zig");
 
 pub const GameLib = @import("GameLib.zig");

--- a/src/lib/flint.zig
+++ b/src/lib/flint.zig
@@ -2,6 +2,7 @@ const INTERNAL: bool = @import("build_options").internal;
 
 pub const sdl = @import("sdl.zig");
 pub const aseprite = @import("aseprite.zig");
+pub const fs = @import("fs.zig");
 pub const imgui = if (INTERNAL) @import("imgui.zig") else struct {
     pub const ImGuiContext: type = anyopaque;
 };

--- a/src/lib/fs.zig
+++ b/src/lib/fs.zig
@@ -1,0 +1,60 @@
+//! Exposes some utilities for working with the file system.
+const std = @import("std");
+
+/// Opens a directory relative to the current working directory.
+/// Falls back to the executable directory if the directory isn't found.
+pub fn openDirRelative(sub_path: []const u8, args: std.fs.Dir.OpenOptions) !std.fs.Dir {
+    if (std.fs.cwd().openDir(sub_path, args)) |directory| {
+        return directory;
+    } else |_| {
+        var buffer: [1024]u8 = undefined;
+        const exe_path = try std.fs.selfExeDirPath(&buffer);
+
+        var exe_dir = try std.fs.cwd().openDir(exe_path, .{});
+        defer exe_dir.close();
+
+        return try exe_dir.openDir(sub_path, args);
+    }
+}
+
+/// Opens a file relative to the current working directory.
+/// Falls back to the executable directory if the file isn't found.
+pub fn openFileRelative(sub_path: []const u8, flags: std.fs.File.OpenFlags) !std.fs.File {
+    if (std.fs.cwd().openFile(sub_path, flags)) |file| {
+        return file;
+    } else |_| {
+        var buffer: [1024]u8 = undefined;
+        const exe_path = try std.fs.selfExeDirPath(&buffer);
+
+        var exe_dir = try std.fs.cwd().openDir(exe_path, .{});
+        defer exe_dir.close();
+
+        return try exe_dir.openFile(sub_path, flags);
+    }
+}
+
+/// Returns the provided path if it exists relative to the current working directory, otherwise it returns the path
+/// relative to the executable directory.
+pub fn getFilePathRelative(sub_path: []const u8, allocator: std.mem.Allocator) ![]const u8 {
+    if (fileExists(sub_path)) {
+        return sub_path;
+    } else {
+        var buffer: [1024]u8 = undefined;
+        const exe_path = try std.fs.selfExeDirPath(&buffer);
+        return try std.fs.path.join(allocator, &.{ exe_path, sub_path });
+    }
+}
+
+/// Checks if a file exists.
+pub fn fileExists(file_name: []const u8) bool {
+    var result: bool = false;
+
+    const opt_file: ?std.fs.File = std.fs.cwd().openFile(file_name, .{ .mode = .read_only }) catch null;
+    defer if (opt_file) |file| file.close();
+
+    if (opt_file != null) {
+        result = true;
+    }
+
+    return result;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -371,12 +371,10 @@ fn loadDll() !void {
     var buffer: [1024]u8 = undefined;
     var lib_path: []const u8 = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ LIB_DEV_DIRECTORY, lib_name });
 
-    if (INTERNAL) {
-        // Try to load the game library from the dev directory.
-        opt_dyn_lib = std.DynLib.open(lib_path) catch null;
-        if (opt_dyn_lib != null) {
-            std.log.info("Loading game library ({s}).", .{lib_path});
-        }
+    // Try to load the game library from the dev directory.
+    opt_dyn_lib = std.DynLib.open(lib_path) catch null;
+    if (opt_dyn_lib != null) {
+        std.log.info("Loading game library ({s}).", .{lib_path});
     }
 
     if (opt_dyn_lib == null) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -309,15 +309,15 @@ fn codeHasChanged(allocator: std.mem.Allocator) bool {
 fn checkForChangesInDirectory(allocator: std.mem.Allocator, path: []const u8, last_change: *i128) !bool {
     var result = false;
 
-    var assets = try std.fs.cwd().openDir(path, .{ .access_sub_paths = true, .iterate = true });
-    defer assets.close();
+    var directory = try flint.fs.openDirRelative(path, .{ .access_sub_paths = true, .iterate = true });
+    defer directory.close();
 
-    var walker = try assets.walk(allocator);
+    var walker = try directory.walk(allocator);
     defer walker.deinit();
 
     while (try walker.next()) |entry| {
         if (entry.kind == .file) {
-            const stat = try assets.statFile(entry.path);
+            const stat = try directory.statFile(entry.path);
             if (stat.mtime > last_change.*) {
                 last_change.* = stat.mtime;
                 result = true;
@@ -338,19 +338,6 @@ fn unloadDll() !void {
     }
 }
 
-fn fileExists(file_name: []const u8) bool {
-    var result: bool = false;
-
-    const opt_file: ?std.fs.File = std.fs.cwd().openFile(file_name, .{ .mode = .read_only }) catch null;
-    defer if (opt_file) |file| file.close();
-
-    if (opt_file != null) {
-        result = true;
-    }
-
-    return result;
-}
-
 fn loadDll() !void {
     if (opt_dyn_lib != null) return error.AlreadyLoaded;
 
@@ -360,7 +347,7 @@ fn loadDll() !void {
     // otherwise the zig build wouldn't be allowed to overwrite the .dll file.
     if (INTERNAL and PLATFORM == .windows) {
         // Only make a copy of the library if we are in the dev directory (zig-out/bin/ on Windows).
-        if (fileExists(LIB_DEV_DIRECTORY ++ LIB_NAME)) {
+        if (flint.fs.fileExists(LIB_DEV_DIRECTORY ++ LIB_NAME)) {
             const temp_copy_name: []const u8 = LIB_BASE_NAME ++ "_temp.dll";
             var dev_directory = try std.fs.cwd().openDir(LIB_DEV_DIRECTORY, .{});
             try dev_directory.copyFile(LIB_NAME, dev_directory, temp_copy_name, .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@ const INTERNAL: bool = @import("build_options").internal;
 const PLATFORM = @import("builtin").os.tag;
 const LIB_BASE_NAME = @import("build_options").lib_base_name;
 
-const LIB_DIRECTORY = if (PLATFORM == .windows) "zig-out/bin/" else "zig-out/lib/";
+const LIB_DEV_DIRECTORY = if (PLATFORM == .windows) "zig-out/bin/" else "zig-out/lib/";
 const LIB_NAME =
     if (PLATFORM == .windows)
         LIB_BASE_NAME ++ ".dll"
@@ -16,7 +16,7 @@ const LIB_NAME =
         "lib" ++ LIB_BASE_NAME ++ ".dylib"
     else
         "lib" ++ LIB_BASE_NAME ++ ".so";
-const LIB_NAME_RUNTIME = if (PLATFORM == .windows and INTERNAL) LIB_BASE_NAME ++ "_temp.dll" else LIB_NAME;
+
 const WINDOW_DECORATIONS_WIDTH = if (PLATFORM == .windows) 0 else 0;
 const WINDOW_DECORATIONS_HEIGHT = if (PLATFORM == .windows) 31 else 0;
 
@@ -33,7 +33,7 @@ pub fn main() !void {
     const allocator = debug_allocator.allocator();
 
     loadDll() catch |err| {
-        std.log.err("Failed to load the game DLL.", .{});
+        std.log.err("Failed to load the game library. Error: {s}", .{@errorName(err)});
         return err;
     };
 
@@ -290,7 +290,7 @@ fn initChangeTimes(allocator: std.mem.Allocator) void {
 
 fn dllHasChanged() bool {
     var result = false;
-    const stat = std.fs.cwd().statFile(LIB_DIRECTORY ++ LIB_NAME) catch return false;
+    const stat = std.fs.cwd().statFile(LIB_DEV_DIRECTORY ++ LIB_NAME) catch return false;
     if (stat.mtime > dyn_lib_last_modified) {
         dyn_lib_last_modified = stat.mtime;
         result = true;
@@ -338,26 +338,68 @@ fn unloadDll() !void {
     }
 }
 
+fn fileExists(file_name: []const u8) bool {
+    var result: bool = false;
+
+    const opt_file: ?std.fs.File = std.fs.cwd().openFile(file_name, .{ .mode = .read_only }) catch null;
+    defer if (opt_file) |file| file.close();
+
+    if (opt_file != null) {
+        result = true;
+    }
+
+    return result;
+}
+
 fn loadDll() !void {
     if (opt_dyn_lib != null) return error.AlreadyLoaded;
 
+    var lib_name: []const u8 = LIB_NAME;
+
+    // For hot reloading the game library to work on Windows we need to load a copy of the library,
+    // otherwise the zig build wouldn't be allowed to overwrite the .dll file.
     if (INTERNAL and PLATFORM == .windows) {
-        var output = try std.fs.cwd().openDir(LIB_DIRECTORY, .{});
-        try output.copyFile(LIB_NAME, output, LIB_NAME_RUNTIME, .{});
+        // Only make a copy of the library if we are in the dev directory (zig-out/bin/ on Windows).
+        if (fileExists(LIB_DEV_DIRECTORY ++ LIB_NAME)) {
+            const temp_copy_name: []const u8 = LIB_BASE_NAME ++ "_temp.dll";
+            var dev_directory = try std.fs.cwd().openDir(LIB_DEV_DIRECTORY, .{});
+            try dev_directory.copyFile(LIB_NAME, dev_directory, temp_copy_name, .{});
+            lib_name = temp_copy_name;
+        }
     }
 
-    opt_dyn_lib = std.DynLib.open(LIB_DIRECTORY ++ LIB_NAME_RUNTIME) catch null;
+    var buffer: [1024]u8 = undefined;
+    var lib_path: []const u8 = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ LIB_DEV_DIRECTORY, lib_name });
+
+    if (INTERNAL) {
+        // Try to load the game library from the dev directory.
+        opt_dyn_lib = std.DynLib.open(lib_path) catch null;
+        if (opt_dyn_lib != null) {
+            std.log.info("Loading game library ({s}).", .{lib_path});
+        }
+    }
+
     if (opt_dyn_lib == null) {
-        std.log.info("Failed to load DLL from first location ({s}).", .{LIB_DIRECTORY ++ LIB_NAME_RUNTIME});
-        opt_dyn_lib = std.DynLib.open(LIB_NAME_RUNTIME) catch {
-            std.log.err("Failed to load DLL from secondary location ({s}).", .{LIB_NAME_RUNTIME});
-            return error.OpenFail;
-        };
+        // Try to load the game library from the current working directory.
+        lib_path = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ "./", lib_name });
+        opt_dyn_lib = std.DynLib.open(lib_path) catch null;
+        if (opt_dyn_lib != null) {
+            std.log.info("Loading game library ({s}).", .{lib_path});
+        }
+    }
+
+    if (opt_dyn_lib == null) {
+        // Try to load the game library from the "lib" directory in the current working directory.
+        lib_path = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ "./lib/", lib_name });
+        opt_dyn_lib = std.DynLib.open(lib_path) catch null;
+        if (opt_dyn_lib != null) {
+            std.log.info("Loading game library ({s}).", .{lib_path});
+        }
     }
 
     if (opt_dyn_lib) |*dyn_lib| {
         try game.load(dyn_lib);
+    } else {
+        return error.LibraryNotFound;
     }
-
-    std.log.info("Game DLL loaded.", .{});
 }


### PR DESCRIPTION
### Added
* Added a module with utilities for dealing with the file system, to begin with it covers Flints own needs.

### Changed
* Changed where we look for the game library to make the executable more portable. The order is now: zig-out if internal build, same directory as executable, and finally a directory called "lib" in the same directory as the executable.
* The workaround to deal with building the game library while it is open on Windows is now only applied if the library is found in the dev directory (zig-out/bin), otherwise we skip it. This allows internal builds to be portable.
* Changed where we look for assets to make the executable more portable. Previously the asset paths only worked relative to the current working directory, now we have a fallback which looks relative to the executable directory if not found in the current directory.