### PR TITLE
Automate builds

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -17,16 +17,38 @@ jobs:
       - name: Build
         run: zig build examples
 
+      - name: Install @actions/artifact
+        run: npm install @actions/artifact
+
+      - name: Extract runtime variables
+        uses: actions/github-script@v9
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL'])
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+
       - name: Upload artifacts
+        shell: node {0}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_PATH: ${{ github.workspace }}/node_modules
+          WORKSPACE: ${{ github.workspace }}
         run: |
-          find examples -mindepth 4 -maxdepth 4 -type d -path "*/zig-out/builds/*" | while IFS= read -r dir; do
-            name=$(basename "$dir")
-            echo "Uploading $dir as $name..."
-            curl -sS -X POST \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Content-Type: application/zip" \
-              "https://uploads.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=${name}" \
-              --data-binary @<(cd "$dir" && zip -r - .)
-          done
+          import { execSync } from 'child_process';
+          import { join, basename } from 'path';
+
+          const workspace = process.env.WORKSPACE;
+          const { DefaultArtifactClient } = await import(
+            join(workspace, 'node_modules/@actions/artifact/lib/artifact.js')
+          );
+
+          const client = new DefaultArtifactClient();
+          const dirs = execSync(
+            `find ${workspace}/examples -mindepth 4 -maxdepth 4 -type d -path '*/zig-out/builds/*'`
+          ).toString().trim().split('\n');
+
+          for (const dir of dirs) {
+            const name = basename(dir);
+            const files = execSync(`find ${dir} -type f`).toString().trim().split('\n');
+            console.log(`Uploading ${dir} as ${name}...`);
+            await client.uploadArtifact(name, files, dir);
+          }

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -17,38 +17,17 @@ jobs:
       - name: Build
         run: zig build examples
 
-      - name: Install @actions/artifact
-        run: npm install @actions/artifact
-
-      - name: Extract runtime variables
-        uses: actions/github-script@v9
+      - uses: actions/upload-artifact@v7
         with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL'])
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+          name: flint-example-template
+          path: examples/template/zig-out/builds/
 
-      - name: Upload artifacts
-        shell: node {0}
-        env:
-          NODE_PATH: ${{ github.workspace }}/node_modules
-          WORKSPACE: ${{ github.workspace }}
-        run: |
-          import { execSync } from 'child_process';
-          import { join, basename } from 'path';
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flint-example-diamonds
+          path: examples/diamonds/zig-out/builds/
 
-          const workspace = process.env.WORKSPACE;
-          const { DefaultArtifactClient } = await import(
-            join(workspace, 'node_modules/@actions/artifact/lib/artifact.js')
-          );
-
-          const client = new DefaultArtifactClient();
-          const dirs = execSync(
-            `find ${workspace}/examples -mindepth 4 -maxdepth 4 -type d -path '*/zig-out/builds/*'`
-          ).toString().trim().split('\n');
-
-          for (const dir of dirs) {
-            const name = basename(dir);
-            const files = execSync(`find ${dir} -type f`).toString().trim().split('\n');
-            console.log(`Uploading ${dir} as ${name}...`);
-            await client.uploadArtifact(name, files, dir);
-          }
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flint-example-cube
+          path: examples/cube/zig-out/builds/

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,5 +1,7 @@
 name: Build examples
-on: [push]
+on:
+  push:
+    branches: [master]
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:

--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -1,0 +1,32 @@
+name: Build examples
+on: [push]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+jobs:
+  build:
+    # Cross compiling for MacOS is technically not allowed by Apple, so we use a MacOS runner for this.
+    # In the future we may need to do something else here since certain platforms probably can't be built from MacOS.
+    runs-on: macos-latest
+    name: Build examples
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mlugg/setup-zig@v2
+        with:
+            version: 0.16.0
+
+      - name: Build
+        run: zig build examples
+
+      - name: Upload artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          find examples -mindepth 4 -maxdepth 4 -type d -path "*/zig-out/builds/*" | while IFS= read -r dir; do
+            name=$(basename "$dir")
+            echo "Uploading $dir as $name..."
+            curl -sS -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Content-Type: application/zip" \
+              "https://uploads.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=${name}" \
+              --data-binary @<(cd "$dir" && zip -r - .)
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is roughly speaking 0.MAJOR.MINOR.PATCH.
 * Added RPath entries to Linux/Mac builds so the executable can find libraries in the executable directory and in ./lib. This allows for packaging the executable with the libraries. On Windows it will follow the normal DLL search order, so it's easiest to place the libraries in the same directory as the executable.
 * Added a module with utilities for dealing with the file system, to begin with it covers Flints own needs.
 * [Breaking] Added a simpler way to integrate the Flint build into a project build.zig by providing a single function that returns both the module and executable. See the Template example for the new suggested setup.
+* Added the ability to define a build matrix that allows automating building of all permutations of your game that you want. It supports three dimensions: target platform, optimize mode, and internal/release builds. This gives a fast way to catch any compilation errors that aren't happening on the native target or in release mode for example. This also includes basic packaging by copying assets, executable, and libraries into the same directory which provides an easy way to test all permutations of the game.
 ### Changed
 * [Breaking] Updated minimum Zig version to 0.16.0.
 * Updated SDL to version 3.4.8.

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const examples = [_][]const u8{
     "examples/template",
 };
+const PLATFORM = @import("builtin").os.tag;
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
@@ -165,6 +166,12 @@ pub fn buildMatrix(
     internal_modes: []const bool,
 ) void {
     for (targets) |target_query| {
+        // Skip MacOS when on a different platform without specifying the sysroot which is required for SDL.
+        if (b.sysroot == null and target_query.os_tag == .macos and target_query.os_tag != PLATFORM) {
+            std.log.info("MacOS skipped since --sysroot was not specified, the Apple SDKs are required for cross compiling to this target.", .{});
+            continue;
+        }
+
         const target = b.resolveTargetQuery(target_query);
         for (optimize_modes) |optimize| {
             for (internal_modes) |internal| {

--- a/build.zig
+++ b/build.zig
@@ -143,7 +143,7 @@ pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
 }
 
 // The buildGame function called by the buildMatrix for each permutation of the matrix.
-const BuildGameFnType = *const fn (b: *std.Build, integrate_options: IntegrateOptions) BuildResult;
+const BuildGameFnType = *const fn (b: *std.Build, flint_options: IntegrateOptions) BuildResult;
 
 // The result expected back from the buildGame function.
 pub const BuildResult = struct {

--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build) !void {
     b.default_step = build_all_step;
 
     // Flint module.
-    const flint_mod = addFlintModule(b, b, target, optimize, build_all_step, build_options_mod, internal);
+    const flint_mod = addFlintModule(b, b, target, optimize, build_all_step, build_options_mod, internal, .default);
 
     // Main executable.
     const exe = addFlintExecutable(b, target, optimize, exe_build_options_mod, flint_mod, "flint");
@@ -85,6 +85,8 @@ pub const IntegrateOptions = struct {
     name: []const u8 = "game",
     lib_only: bool = false,
     disable_run: bool = false,
+    install_step: *std.Build.Step,
+    dest_dir: std.Build.Step.InstallArtifact.Options.Dir,
 };
 
 pub const IntegrateResult = struct {
@@ -105,9 +107,10 @@ pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
         b,
         options.target,
         options.optimize,
-        b.getInstallStep(),
+        options.install_step,
         build_options_mod,
         options.internal,
+        options.dest_dir,
     );
 
     var exe: ?*std.Build.Step.Compile = null;
@@ -147,6 +150,7 @@ pub fn addFlintModule(
     install_step: *std.Build.Step,
     build_options_mod: *std.Build.Module,
     internal: bool,
+    dest_dir: std.Build.Step.InstallArtifact.Options.Dir,
 ) *std.Build.Module {
     const flint_mod = b.addModule("flint", .{
         .root_source_file = b.path("src/lib/flint.zig"),
@@ -160,7 +164,7 @@ pub fn addFlintModule(
     if (internal) {
         linkImgui(b, flint_mod, target, optimize, install_step);
     }
-    linkSDL(b, client_b, flint_mod, target, optimize, install_step);
+    linkSDL(b, client_b, flint_mod, target, optimize, install_step, dest_dir);
     return flint_mod;
 }
 
@@ -205,6 +209,7 @@ fn linkSDL(
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
     install_step: *std.Build.Step,
+    dest_dir: std.Build.Step.InstallArtifact.Options.Dir,
 ) void {
     if (getSDL(b, target, optimize)) |sdl_lib| {
         const translate_c = b.addTranslateC(.{
@@ -218,7 +223,7 @@ fn linkSDL(
         module.addImport("sdl_c", translate_c.createModule());
 
         module.linkLibrary(sdl_lib);
-        install_step.dependOn(&client_b.addInstallArtifact(sdl_lib, .{}).step);
+        install_step.dependOn(&client_b.addInstallArtifact(sdl_lib, .{ .dest_dir = dest_dir }).step);
     }
 }
 

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ const EXAMPLE_PATHS = [_][]const u8{
     "examples/cube",
 };
 const PLATFORM = @import("builtin").os.tag;
+const PLATFORM_CPU = @import("builtin").target.cpu;
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
@@ -174,6 +175,9 @@ pub fn buildMatrix(
             continue;
         }
 
+        // If we are building for the same OS and CPU as the build is running on we consider it a native build.
+        const use_native_query = (target_query.os_tag == PLATFORM and target_query.cpu_arch == PLATFORM_CPU.arch);
+
         const target = b.resolveTargetQuery(target_query);
         for (optimize_modes) |optimize| {
             for (internal_modes) |internal| {
@@ -187,7 +191,11 @@ pub fn buildMatrix(
                 const dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .{ .override = .{ .custom = dest_path } };
                 const result = buildGame(b, .{
                     .dependency = options.dependency,
-                    .target = target,
+                    // Workaround for the fact that zig build system considers any values in the target query to be
+                    // non-native even if they match the build machine. Without this the SDL build.zig will complain
+                    // about missing --sysroot even when we are running on MacOS and don't actually need to specify it.
+                    // By passing a the default target in this case the target will be considered native.
+                    .target = if (use_native_query) options.target else target,
                     .optimize = optimize,
                     .build_options = b.addOptions(),
                     .name = options.name,

--- a/build.zig
+++ b/build.zig
@@ -142,6 +142,73 @@ pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
     };
 }
 
+// The buildGame function called by the buildMatrix for each permutation of the matrix.
+const BuildGameFnType = *const fn (b: *std.Build, integrate_options: IntegrateOptions) BuildResult;
+
+// The result expected back from the buildGame function.
+pub const BuildResult = struct {
+    exe: ?*std.Build.Step.Compile,
+    lib: *std.Build.Step.Compile,
+    assets_path: ?std.Build.LazyPath,
+};
+
+/// This allows building various permutations of your game for testing purposes. The results will be placed in the
+/// ./zig-out/builds directory of your project. The buildGame function is called on each permutation, that function is
+/// where you place all the build logic your game needs.
+pub fn buildMatrix(
+    b: *std.Build,
+    step: *std.Build.Step,
+    options: IntegrateOptions,
+    buildGame: BuildGameFnType,
+    targets: []const std.Target.Query,
+    optimize_modes: []const std.builtin.OptimizeMode,
+    internal_modes: []const bool,
+) void {
+    for (targets) |target_query| {
+        const target = b.resolveTargetQuery(target_query);
+        for (optimize_modes) |optimize| {
+            for (internal_modes) |internal| {
+                const dest_path: []const u8 = b.fmt("builds/{s}-{s}-{s}-{s}-{s}", .{
+                    options.name,
+                    @tagName(target_query.os_tag.?),
+                    @tagName(target_query.cpu_arch.?),
+                    @tagName(optimize),
+                    if (internal) "internal" else "release",
+                });
+                const dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .{ .override = .{ .custom = dest_path } };
+                const result = buildGame(b, .{
+                    .dependency = options.dependency,
+                    .target = target,
+                    .optimize = optimize,
+                    .build_options = b.addOptions(),
+                    .name = options.name,
+                    .internal = internal,
+                    .disable_run = true,
+                    .install_step = step,
+                    .dest_dir = dest_dir,
+                });
+
+                // Install executable.
+                if (result.exe) |exe| {
+                    step.dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = dest_dir }).step);
+                }
+
+                // Install game library.
+                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = dest_dir }).step);
+
+                // Install game assets.
+                if (result.assets_path) |assets_path| {
+                    step.dependOn(&b.addInstallDirectory(.{
+                        .source_dir = assets_path,
+                        .install_dir = .{ .custom = dest_path },
+                        .install_subdir = "assets",
+                    }).step);
+                }
+            }
+        }
+    }
+}
+
 pub fn addFlintModule(
     b: *std.Build,
     client_b: *std.Build,

--- a/build.zig
+++ b/build.zig
@@ -84,9 +84,9 @@ pub const IntegrateOptions = struct {
     internal: bool = true,
     name: []const u8 = "game",
     lib_only: bool = false,
-    disable_run: bool = false,
+    skip_run_step: bool = false,
     install_step: *std.Build.Step,
-    dest_dir: std.Build.Step.InstallArtifact.Options.Dir,
+    dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .default,
 };
 
 pub const IntegrateResult = struct {
@@ -124,7 +124,7 @@ pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
             options.name,
         );
 
-        if (!options.disable_run) {
+        if (!options.skip_run_step) {
             const run_step = b.step("run", "Run the game");
             const run_cmd = b.addRunArtifact(exe.?);
             run_cmd.step.dependOn(b.getInstallStep());
@@ -183,7 +183,7 @@ pub fn buildMatrix(
                     .build_options = b.addOptions(),
                     .name = options.name,
                     .internal = internal,
-                    .disable_run = true,
+                    .skip_run_step = true,
                     .install_step = step,
                     .dest_dir = dest_dir,
                 });

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,13 @@
 const std = @import("std");
+const integration = @import("src/lib/build/integration.zig");
+const MatrixStep = @import("src/lib/build/MatrixStep.zig");
+
+// Types.
+pub const IntegrateOptions = integration.IntegrateOptions;
+pub const IntegrateResult = integration.IntegrateResult;
+pub const BuildMatrixStep = MatrixStep;
+pub const BuildGameFnType = MatrixStep.BuildGameFnType;
+pub const BuildResult = MatrixStep.BuildResult;
 
 const EXAMPLE_PATHS = [_][]const u8{
     "examples/template",
@@ -80,25 +89,6 @@ pub fn build(b: *std.Build) !void {
     buildNewExecutable(b, exe_build_options_mod, target);
 }
 
-pub const IntegrateOptions = struct {
-    dependency: *std.Build.Dependency,
-    target: std.Build.ResolvedTarget,
-    optimize: std.builtin.OptimizeMode,
-    build_options: *std.Build.Step.Options,
-    internal: bool = true,
-    name: []const u8 = "game",
-    lib_only: bool = false,
-    skip_run_step: bool = false,
-    install_step: *std.Build.Step,
-    dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .default,
-};
-
-pub const IntegrateResult = struct {
-    flint_mod: *std.Build.Module,
-    exe: ?*std.Build.Step.Compile,
-    build_options_mod: *std.Build.Module,
-};
-
 pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
     const flint_b = options.dependency.builder;
 
@@ -144,86 +134,6 @@ pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
         .exe = exe,
         .build_options_mod = build_options_mod,
     };
-}
-
-// The buildGame function called by the buildMatrix for each permutation of the matrix.
-const BuildGameFnType = *const fn (b: *std.Build, flint_options: IntegrateOptions) BuildResult;
-
-// The result expected back from the buildGame function.
-pub const BuildResult = struct {
-    exe: ?*std.Build.Step.Compile,
-    lib: *std.Build.Step.Compile,
-    assets_path: ?std.Build.LazyPath,
-};
-
-/// This allows building various permutations of your game for testing purposes. The results will be placed in the
-/// ./zig-out/builds directory of your project. The buildGame function is called on each permutation, that function is
-/// where you place all the build logic your game needs.
-pub fn buildMatrix(
-    b: *std.Build,
-    step: *std.Build.Step,
-    options: IntegrateOptions,
-    buildGame: BuildGameFnType,
-    targets: []const std.Target.Query,
-    optimize_modes: []const std.builtin.OptimizeMode,
-    internal_modes: []const bool,
-) void {
-    for (targets) |target_query| {
-        // Skip MacOS when on a different platform without specifying the sysroot which is required for SDL.
-        if (b.sysroot == null and target_query.os_tag == .macos and target_query.os_tag != PLATFORM) {
-            std.log.info("MacOS skipped since --sysroot was not specified, the Apple SDKs are required for cross compiling to this target.", .{});
-            continue;
-        }
-
-        // If we are building for the same OS and CPU as the build is running on we consider it a native build.
-        const use_native_query = (target_query.os_tag == PLATFORM and target_query.cpu_arch == PLATFORM_CPU.arch);
-
-        const target = b.resolveTargetQuery(target_query);
-        for (optimize_modes) |optimize| {
-            for (internal_modes) |internal| {
-                const dest_path: []const u8 = b.fmt("builds/{s}-{s}-{s}-{s}-{s}", .{
-                    options.name,
-                    @tagName(target_query.os_tag.?),
-                    @tagName(target_query.cpu_arch.?),
-                    @tagName(optimize),
-                    if (internal) "internal" else "release",
-                });
-                const dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .{ .override = .{ .custom = dest_path } };
-                const result = buildGame(b, .{
-                    .dependency = options.dependency,
-                    // Workaround for the fact that zig build system considers any values in the target query to be
-                    // non-native even if they match the build machine. Without this the SDL build.zig will complain
-                    // about missing --sysroot even when we are running on MacOS and don't actually need to specify it.
-                    // By passing a the default target in this case the target will be considered native.
-                    .target = if (use_native_query) options.target else target,
-                    .optimize = optimize,
-                    .build_options = b.addOptions(),
-                    .name = options.name,
-                    .internal = internal,
-                    .skip_run_step = true,
-                    .install_step = step,
-                    .dest_dir = dest_dir,
-                });
-
-                // Install executable.
-                if (result.exe) |exe| {
-                    step.dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = dest_dir }).step);
-                }
-
-                // Install game library.
-                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = dest_dir }).step);
-
-                // Install game assets.
-                if (result.assets_path) |assets_path| {
-                    step.dependOn(&b.addInstallDirectory(.{
-                        .source_dir = assets_path,
-                        .install_dir = .{ .custom = dest_path },
-                        .install_subdir = "assets",
-                    }).step);
-                }
-            }
-        }
-    }
 }
 
 pub fn addFlintModule(

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+const examples = [_][]const u8{
+    "examples/template",
+};
+
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -37,6 +41,19 @@ pub fn build(b: *std.Build) !void {
     const run_lib_tests = b.addRunArtifact(lib_tests);
     test_step.dependOn(&run_lib_tests.step);
 
+    // Build all examples.
+    const build_examples_step = b.step("examples", "Builds all permutations of the examples for testing purposes.");
+    for (examples) |example_path| {
+        const build_example_cmd = b.addSystemCommand(&.{
+            "zig",
+            "build",
+            "all",
+            "--build-file",
+            b.fmt("{s}/build.zig", .{example_path}),
+        });
+        build_examples_step.dependOn(&build_example_cmd.step);
+    }
+
     // Docs.
     const docs_mod = b.addModule("docs", .{
         .root_source_file = b.path("src/lib/docs.zig"),
@@ -67,6 +84,7 @@ pub const IntegrateOptions = struct {
     internal: bool = true,
     name: []const u8 = "game",
     lib_only: bool = false,
+    disable_run: bool = false,
 };
 
 pub const IntegrateResult = struct {
@@ -103,13 +121,15 @@ pub fn integrate(b: *std.Build, options: IntegrateOptions) IntegrateResult {
             options.name,
         );
 
-        const run_step = b.step("run", "Run the game");
-        const run_cmd = b.addRunArtifact(exe.?);
-        run_cmd.step.dependOn(b.getInstallStep());
-        if (b.args) |args| {
-            run_cmd.addArgs(args);
+        if (!options.disable_run) {
+            const run_step = b.step("run", "Run the game");
+            const run_cmd = b.addRunArtifact(exe.?);
+            run_cmd.step.dependOn(b.getInstallStep());
+            if (b.args) |args| {
+                run_cmd.addArgs(args);
+            }
+            run_step.dependOn(&run_cmd.step);
         }
-        run_step.dependOn(&run_cmd.step);
     }
 
     return .{

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 
-const examples = [_][]const u8{
+const EXAMPLE_PATHS = [_][]const u8{
     "examples/template",
+    "examples/diamonds",
+    "examples/cube",
 };
 const PLATFORM = @import("builtin").os.tag;
 
@@ -44,7 +46,7 @@ pub fn build(b: *std.Build) !void {
 
     // Build all examples.
     const build_examples_step = b.step("examples", "Builds all permutations of the examples for testing purposes.");
-    for (examples) |example_path| {
+    for (EXAMPLE_PATHS) |example_path| {
         const build_example_cmd = b.addSystemCommand(&.{
             "zig",
             "build",

--- a/examples/cube/build.zig
+++ b/examples/cube/build.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 const flint = @import("flint");
 
+const TARGETS = [_]std.Target.Query{
+    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+};
+const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
+const INTERNAL_MODES = [_]bool{ true, false };
+
 const SHADER_FORMATS: []const []const u8 = &.{ "spv", "msl", "dxil" };
 const SHADERS: []const []const u8 = &.{
     "cube.vert",
@@ -9,77 +17,53 @@ const SHADERS: []const []const u8 = &.{
     "screen.frag",
 };
 
+var log_allocations: bool = false;
+
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "name of the shared library") orelse "cube";
     const internal = b.option(bool, "internal", "include debug interface") orelse true;
     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
-    const log_allocations = b.option(bool, "log_allocations", "log all allocations") orelse false;
+    log_allocations = b.option(bool, "log_allocations", "log all allocations") orelse false;
 
     // Integrate Flint.
-    const build_options = b.addOptions();
-    build_options.addOption(bool, "log_allocations", log_allocations);
-
-    const result = flint.integrate(b, .{
+    const flint_options: flint.IntegrateOptions = .{
         .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
         .target = target,
         .optimize = optimize,
-        .build_options = build_options,
+        .build_options = b.addOptions(),
         .name = name,
         .internal = internal,
         .lib_only = lib_only,
-    });
+        .install_step = b.getInstallStep(),
+    };
+    const result = buildGame(b, flint_options);
 
-    // Game library.
-    const module = b.createModule(.{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    module.addImport("build_options", result.build_options_mod);
-    module.addImport("flint", result.flint_mod);
+    // Build all variations.
+    const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
+    flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
 
-    const lib = b.addLibrary(.{
-        .linkage = .dynamic,
-        .name = name,
-        .root_module = module,
-        .use_llvm = true,
-    });
-    b.getInstallStep().dependOn(&b.addInstallArtifact(lib, .{}).step);
-
+    // Install executable.
     if (result.exe) |exe| {
         b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{}).step);
     }
 
+    // Install library.
+    b.getInstallStep().dependOn(&b.addInstallArtifact(result.lib, .{}).step);
+
+    // Check library.
     const lib_check = b.addLibrary(.{
         .linkage = .dynamic,
         .name = name,
-        .root_module = module,
+        .root_module = result.lib.root_module,
     });
     const check = b.step("check", "Check if it compiles");
     check.dependOn(&lib_check.step);
 
-    const logging_allocator_mod = b.createModule(.{
-        .root_source_file = b.path("../logging_allocator.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    const math_mod = b.createModule(.{
-        .root_source_file = b.path("../math.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "flint", .module = result.flint_mod },
-        },
-    });
-
-    module.addImport("math", math_mod);
-    module.addImport("logging_allocator", logging_allocator_mod);
-
     // Tests.
     const test_step = b.step("test", "Run unit tests");
-    const lib_tests = b.addTest(.{ .root_module = lib.root_module });
+    const lib_tests = b.addTest(.{ .root_module = result.lib.root_module });
     const run_lib_tests = b.addRunArtifact(lib_tests);
     test_step.dependOn(&run_lib_tests.step);
 
@@ -103,4 +87,48 @@ pub fn build(b: *std.Build) !void {
     }
 
     b.getInstallStep().dependOn(compile_shaders_step);
+}
+
+fn buildGame(
+    b: *std.Build,
+    flint_options: flint.IntegrateOptions,
+) flint.BuildResult {
+    // Custom build options.
+    flint_options.build_options.addOption(bool, "log_allocations", log_allocations);
+
+    // Integrate Flint.
+    const result = flint.integrate(b, flint_options);
+
+    // Game library.
+    const module = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
+    });
+    const logging_allocator_mod = b.createModule(.{
+        .root_source_file = b.path("../logging_allocator.zig"),
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
+    });
+    const math_mod = b.createModule(.{
+        .root_source_file = b.path("../math.zig"),
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
+        .imports = &.{
+            .{ .name = "flint", .module = result.flint_mod },
+        },
+    });
+    module.addImport("build_options", result.build_options_mod);
+    module.addImport("flint", result.flint_mod);
+    module.addImport("logging_allocator", logging_allocator_mod);
+    module.addImport("math", math_mod);
+
+    const lib = b.addLibrary(.{
+        .name = flint_options.name,
+        .linkage = .dynamic,
+        .root_module = module,
+        .use_llvm = true,
+    });
+
+    return .{ .exe = result.exe, .lib = lib, .assets_path = b.path("assets") };
 }

--- a/examples/cube/build.zig
+++ b/examples/cube/build.zig
@@ -42,7 +42,8 @@ pub fn build(b: *std.Build) !void {
 
     // Build all variations.
     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
-    flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
+    const build_matrix = flint.BuildMatrixStep.create(b, .{ .options = flint_options, .buildGame = &buildGame });
+    build_all_step.dependOn(&build_matrix.step);
 
     // Install executable.
     if (result.exe) |exe| {

--- a/examples/cube/build.zig
+++ b/examples/cube/build.zig
@@ -4,7 +4,7 @@ const flint = @import("flint");
 const TARGETS = [_]std.Target.Query{
     .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
-    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+    .{ .cpu_arch = .aarch64, .os_tag = .macos },
 };
 const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
 const INTERNAL_MODES = [_]bool{ true, false };

--- a/examples/diamonds/build.zig
+++ b/examples/diamonds/build.zig
@@ -34,7 +34,8 @@ pub fn build(b: *std.Build) void {
 
     // Build all variations.
     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
-    flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
+    const build_matrix = flint.BuildMatrixStep.create(b, .{ .options = flint_options, .buildGame = &buildGame });
+    build_all_step.dependOn(&build_matrix.step);
 
     // Install executable.
     if (result.exe) |exe| {

--- a/examples/diamonds/build.zig
+++ b/examples/diamonds/build.zig
@@ -4,7 +4,7 @@ const flint = @import("flint");
 const TARGETS = [_]std.Target.Query{
     .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
-    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+    .{ .cpu_arch = .aarch64, .os_tag = .macos },
 };
 const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
 const INTERNAL_MODES = [_]bool{ true, false };

--- a/examples/diamonds/build.zig
+++ b/examples/diamonds/build.zig
@@ -1,75 +1,105 @@
 const std = @import("std");
 const flint = @import("flint");
 
+const TARGETS = [_]std.Target.Query{
+    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+};
+const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
+const INTERNAL_MODES = [_]bool{ true, false };
+
+var log_allocations: bool = false;
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const name = b.option([]const u8, "name", "name of the game (used for exe and lib)") orelse "diamonds";
     const internal = b.option(bool, "internal", "include debug interface") orelse true;
     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
-    const log_allocations = b.option(bool, "log_allocations", "log all allocations") orelse false;
+    log_allocations = b.option(bool, "log_allocations", "log all allocations") orelse false;
 
     // Integrate Flint.
-    const build_options = b.addOptions();
-    build_options.addOption(bool, "log_allocations", log_allocations);
-
-    const result = flint.integrate(b, .{
+    const flint_options: flint.IntegrateOptions = .{
         .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
         .target = target,
         .optimize = optimize,
-        .build_options = build_options,
+        .build_options = b.addOptions(),
         .name = name,
         .internal = internal,
         .lib_only = lib_only,
-    });
+        .install_step = b.getInstallStep(),
+    };
+    const result = buildGame(b, flint_options);
 
-    // Game library.
-    const module = b.createModule(.{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    module.addImport("build_options", result.build_options_mod);
-    module.addImport("flint", result.flint_mod);
+    // Build all variations.
+    const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
+    flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
 
-    const lib = b.addLibrary(.{
-        .linkage = .dynamic,
-        .name = name,
-        .root_module = module,
-        .use_llvm = true,
-    });
-    b.getInstallStep().dependOn(&b.addInstallArtifact(lib, .{}).step);
-
+    // Install executable.
     if (result.exe) |exe| {
         b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{}).step);
     }
 
+    // Install library.
+    b.getInstallStep().dependOn(&b.addInstallArtifact(result.lib, .{}).step);
+
+    // Check library.
     const lib_check = b.addLibrary(.{
         .linkage = .dynamic,
         .name = name,
-        .root_module = module,
+        .root_module = result.lib.root_module,
     });
     const check = b.step("check", "Check if it compiles");
     check.dependOn(&lib_check.step);
 
+    // Tests.
+    const test_step = b.step("test", "Run unit tests");
+    const lib_tests = b.addTest(.{ .root_module = result.lib.root_module });
+    const run_lib_tests = b.addRunArtifact(lib_tests);
+    test_step.dependOn(&run_lib_tests.step);
+}
+
+fn buildGame(
+    b: *std.Build,
+    flint_options: flint.IntegrateOptions,
+) flint.BuildResult {
+    // Custom build options.
+    flint_options.build_options.addOption(bool, "log_allocations", log_allocations);
+
+    // Integrate Flint.
+    const result = flint.integrate(b, flint_options);
+
+    // Game library.
+    const module = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
+    });
     const logging_allocator_mod = b.createModule(.{
         .root_source_file = b.path("../logging_allocator.zig"),
-        .target = target,
-        .optimize = optimize,
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
     });
     const math_mod = b.createModule(.{
         .root_source_file = b.path("../math.zig"),
-        .target = target,
-        .optimize = optimize,
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
         .imports = &.{
             .{ .name = "flint", .module = result.flint_mod },
         },
     });
-    module.addImport("math", math_mod);
+    module.addImport("build_options", result.build_options_mod);
+    module.addImport("flint", result.flint_mod);
     module.addImport("logging_allocator", logging_allocator_mod);
+    module.addImport("math", math_mod);
 
-    const test_step = b.step("test", "Run unit tests");
-    const lib_tests = b.addTest(.{ .root_module = lib.root_module });
-    const run_lib_tests = b.addRunArtifact(lib_tests);
-    test_step.dependOn(&run_lib_tests.step);
+    const lib = b.addLibrary(.{
+        .name = flint_options.name,
+        .linkage = .dynamic,
+        .root_module = module,
+        .use_llvm = true,
+    });
+
+    return .{ .exe = result.exe, .lib = lib, .assets_path = b.path("assets") };
 }

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -1,6 +1,14 @@
 const std = @import("std");
 const flint = @import("flint");
 
+const TARGETS = [_]std.Target.Query{
+    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+};
+const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
+const INTERNAL_MODES = [_]bool{ true, false };
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -22,9 +30,9 @@ pub fn build(b: *std.Build) void {
     };
     const result = buildGame(b, flint_options);
 
-    // Build all.
+    // Build all variations.
     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
-    buildMatrix(b, build_all_step, flint_options);
+    flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
 
     // Install executable.
     if (result.exe) |exe| {
@@ -50,15 +58,10 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_lib_tests.step);
 }
 
-const BuildResult = struct {
-    exe: ?*std.Build.Step.Compile,
-    lib: *std.Build.Step.Compile,
-};
-
 fn buildGame(
     b: *std.Build,
     integrate_options: flint.IntegrateOptions,
-) BuildResult {
+) flint.BuildResult {
     // Integrate Flint.
     const result = flint.integrate(b, integrate_options);
 
@@ -78,57 +81,5 @@ fn buildGame(
         .use_llvm = true,
     });
 
-    return .{ .exe = result.exe, .lib = lib };
-}
-
-const targets = [_]std.Target.Query{
-    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
-    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
-    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
-};
-const optimize_modes = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
-const internal_modes = [_]bool{ true, false };
-
-fn buildMatrix(b: *std.Build, step: *std.Build.Step, options: flint.IntegrateOptions) void {
-    for (targets) |target_query| {
-        const target = b.resolveTargetQuery(target_query);
-        for (optimize_modes) |optimize| {
-            for (internal_modes) |internal| {
-                const dest_path: []const u8 = b.fmt("builds/{s}-{s}-{s}-{s}-{s}", .{
-                    options.name,
-                    @tagName(target_query.os_tag.?),
-                    @tagName(target_query.cpu_arch.?),
-                    @tagName(optimize),
-                    if (internal) "internal" else "release",
-                });
-                const dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .{ .override = .{ .custom = dest_path } };
-                const result = buildGame(b, .{
-                    .dependency = options.dependency,
-                    .target = target,
-                    .optimize = optimize,
-                    .build_options = b.addOptions(),
-                    .name = options.name,
-                    .internal = internal,
-                    .disable_run = true,
-                    .install_step = step,
-                    .dest_dir = dest_dir,
-                });
-
-                // Install executable.
-                if (result.exe) |exe| {
-                    step.dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = dest_dir }).step);
-                }
-
-                // Install game library.
-                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = dest_dir }).step);
-
-                // Install game assets.
-                step.dependOn(&b.addInstallDirectory(.{
-                    .source_dir = b.path("assets"),
-                    .install_dir = .{ .custom = dest_path },
-                    .install_subdir = "assets",
-                }).step);
-            }
-        }
-    }
+    return .{ .exe = result.exe, .lib = lib, .assets_path = b.path("assets") };
 }

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -8,6 +8,51 @@ pub fn build(b: *std.Build) void {
     const internal = b.option(bool, "internal", "include debug interface") orelse true;
     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
 
+    // Build game.
+    const result = buildGame(b, target, optimize, name, internal, lib_only, false);
+
+    // Build all.
+    const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
+    buildMatrix(b, name, build_all_step);
+
+    // Install executable.
+    if (result.exe) |exe| {
+        b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{}).step);
+    }
+
+    // Install library.
+    b.getInstallStep().dependOn(&b.addInstallArtifact(result.lib, .{}).step);
+
+    // Check library.
+    const lib_check = b.addLibrary(.{
+        .name = name,
+        .linkage = .dynamic,
+        .root_module = result.lib.root_module,
+    });
+    const check = b.step("check", "Check if it compiles");
+    check.dependOn(&lib_check.step);
+
+    // Tests.
+    const test_step = b.step("test", "Run unit tests");
+    const lib_tests = b.addTest(.{ .root_module = result.lib.root_module });
+    const run_lib_tests = b.addRunArtifact(lib_tests);
+    test_step.dependOn(&run_lib_tests.step);
+}
+
+const BuildResult = struct {
+    exe: ?*std.Build.Step.Compile,
+    lib: *std.Build.Step.Compile,
+};
+
+fn buildGame(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    name: []const u8,
+    internal: bool,
+    lib_only: bool,
+    disbable_run: bool,
+) BuildResult {
     // Integrate Flint.
     const result = flint.integrate(b, .{
         .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
@@ -17,6 +62,7 @@ pub fn build(b: *std.Build) void {
         .name = name,
         .internal = internal,
         .lib_only = lib_only,
+        .disable_run = disbable_run,
     });
 
     // Game library.
@@ -34,23 +80,43 @@ pub fn build(b: *std.Build) void {
         .root_module = module,
         .use_llvm = true,
     });
-    b.getInstallStep().dependOn(&b.addInstallArtifact(lib, .{}).step);
 
-    if (result.exe) |exe| {
-        b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{}).step);
+    return .{ .exe = result.exe, .lib = lib };
+}
+
+const targets = [_]std.Target.Query{
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
+};
+const optimize_modes = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
+const internal_modes = [_]bool{ true, false };
+
+fn buildMatrix(b: *std.Build, name: []const u8, step: *std.Build.Step) void {
+    for (targets) |target_query| {
+        const target = b.resolveTargetQuery(target_query);
+        for (optimize_modes) |optimize| {
+            for (internal_modes) |internal| {
+                const result = buildGame(b, target, optimize, name, internal, false, true);
+                const dest = b.fmt("builds/template-{s}-{s}-{s}-{s}", .{
+                    @tagName(target_query.os_tag.?),
+                    @tagName(target_query.cpu_arch.?),
+                    @tagName(optimize),
+                    if (internal) "internal" else "release",
+                });
+
+                // Executable.
+                if (result.exe) |exe| {
+                    step.dependOn(&b.addInstallArtifact(exe, .{
+                        .dest_dir = .{ .override = .{ .custom = dest } },
+                    }).step);
+                }
+
+                // Game library.
+                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = .{
+                    .override = .{ .custom = dest },
+                } }).step);
+            }
+        }
     }
-
-    const lib_check = b.addLibrary(.{
-        .name = name,
-        .linkage = .dynamic,
-        .root_module = module,
-    });
-    const check = b.step("check", "Check if it compiles");
-    check.dependOn(&lib_check.step);
-
-    // Tests.
-    const test_step = b.step("test", "Run unit tests");
-    const lib_tests = b.addTest(.{ .root_module = lib.root_module });
-    const run_lib_tests = b.addRunArtifact(lib_tests);
-    test_step.dependOn(&run_lib_tests.step);
 }

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -4,7 +4,7 @@ const flint = @import("flint");
 const TARGETS = [_]std.Target.Query{
     .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
-    // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+    .{ .cpu_arch = .aarch64, .os_tag = .macos },
 };
 const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
 const INTERNAL_MODES = [_]bool{ true, false };

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -114,13 +114,20 @@ fn buildMatrix(b: *std.Build, step: *std.Build.Step, options: flint.IntegrateOpt
                     .dest_dir = dest_dir,
                 });
 
-                // Executable.
+                // Install executable.
                 if (result.exe) |exe| {
                     step.dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = dest_dir }).step);
                 }
 
-                // Game library.
+                // Install game library.
                 step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = dest_dir }).step);
+
+                // Install game assets.
+                step.dependOn(&b.addInstallDirectory(.{
+                    .source_dir = b.path("assets"),
+                    .install_dir = .{ .custom = dest_path },
+                    .install_subdir = "assets",
+                }).step);
             }
         }
     }

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -9,11 +9,22 @@ pub fn build(b: *std.Build) void {
     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
 
     // Build game.
-    const result = buildGame(b, target, optimize, name, internal, lib_only, false);
+    const flint_options: flint.IntegrateOptions = .{
+        .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
+        .target = target,
+        .optimize = optimize,
+        .build_options = b.addOptions(),
+        .name = name,
+        .internal = internal,
+        .lib_only = lib_only,
+        .install_step = b.getInstallStep(),
+        .dest_dir = .default,
+    };
+    const result = buildGame(b, flint_options);
 
     // Build all.
     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
-    buildMatrix(b, name, build_all_step);
+    buildMatrix(b, build_all_step, flint_options);
 
     // Install executable.
     if (result.exe) |exe| {
@@ -46,36 +57,22 @@ const BuildResult = struct {
 
 fn buildGame(
     b: *std.Build,
-    target: std.Build.ResolvedTarget,
-    optimize: std.builtin.OptimizeMode,
-    name: []const u8,
-    internal: bool,
-    lib_only: bool,
-    disbable_run: bool,
+    integrate_options: flint.IntegrateOptions,
 ) BuildResult {
     // Integrate Flint.
-    const result = flint.integrate(b, .{
-        .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
-        .target = target,
-        .optimize = optimize,
-        .build_options = b.addOptions(),
-        .name = name,
-        .internal = internal,
-        .lib_only = lib_only,
-        .disable_run = disbable_run,
-    });
+    const result = flint.integrate(b, integrate_options);
 
     // Game library.
     const module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
+        .target = integrate_options.target,
+        .optimize = integrate_options.optimize,
     });
     module.addImport("build_options", result.build_options_mod);
     module.addImport("flint", result.flint_mod);
 
     const lib = b.addLibrary(.{
-        .name = name,
+        .name = integrate_options.name,
         .linkage = .dynamic,
         .root_module = module,
         .use_llvm = true,
@@ -92,30 +89,38 @@ const targets = [_]std.Target.Query{
 const optimize_modes = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
 const internal_modes = [_]bool{ true, false };
 
-fn buildMatrix(b: *std.Build, name: []const u8, step: *std.Build.Step) void {
+fn buildMatrix(b: *std.Build, step: *std.Build.Step, options: flint.IntegrateOptions) void {
     for (targets) |target_query| {
         const target = b.resolveTargetQuery(target_query);
         for (optimize_modes) |optimize| {
             for (internal_modes) |internal| {
-                const result = buildGame(b, target, optimize, name, internal, false, true);
-                const dest = b.fmt("builds/template-{s}-{s}-{s}-{s}", .{
+                const dest_path: []const u8 = b.fmt("builds/{s}-{s}-{s}-{s}-{s}", .{
+                    options.name,
                     @tagName(target_query.os_tag.?),
                     @tagName(target_query.cpu_arch.?),
                     @tagName(optimize),
                     if (internal) "internal" else "release",
                 });
+                const dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .{ .override = .{ .custom = dest_path } };
+                const result = buildGame(b, .{
+                    .dependency = options.dependency,
+                    .target = target,
+                    .optimize = optimize,
+                    .build_options = b.addOptions(),
+                    .name = options.name,
+                    .internal = internal,
+                    .disable_run = true,
+                    .install_step = step,
+                    .dest_dir = dest_dir,
+                });
 
                 // Executable.
                 if (result.exe) |exe| {
-                    step.dependOn(&b.addInstallArtifact(exe, .{
-                        .dest_dir = .{ .override = .{ .custom = dest } },
-                    }).step);
+                    step.dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = dest_dir }).step);
                 }
 
                 // Game library.
-                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = .{
-                    .override = .{ .custom = dest },
-                } }).step);
+                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = dest_dir }).step);
             }
         }
     }

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -1,14 +1,6 @@
 const std = @import("std");
 const flint = @import("flint");
 
-const TARGETS = [_]std.Target.Query{
-    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
-    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
-    .{ .cpu_arch = .aarch64, .os_tag = .macos },
-};
-const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
-const INTERNAL_MODES = [_]bool{ true, false };
-
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -32,7 +24,8 @@ pub fn build(b: *std.Build) void {
 
     // Build all variations.
     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
-    flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
+    const build_matrix = flint.BuildMatrixStep.create(b, .{ .options = flint_options, .buildGame = &buildGame });
+    build_all_step.dependOn(&build_matrix.step);
 
     // Install executable.
     if (result.exe) |exe| {

--- a/examples/template/build.zig
+++ b/examples/template/build.zig
@@ -60,22 +60,22 @@ pub fn build(b: *std.Build) void {
 
 fn buildGame(
     b: *std.Build,
-    integrate_options: flint.IntegrateOptions,
+    flint_options: flint.IntegrateOptions,
 ) flint.BuildResult {
     // Integrate Flint.
-    const result = flint.integrate(b, integrate_options);
+    const result = flint.integrate(b, flint_options);
 
     // Game library.
     const module = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
-        .target = integrate_options.target,
-        .optimize = integrate_options.optimize,
+        .target = flint_options.target,
+        .optimize = flint_options.optimize,
     });
     module.addImport("build_options", result.build_options_mod);
     module.addImport("flint", result.flint_mod);
 
     const lib = b.addLibrary(.{
-        .name = integrate_options.name,
+        .name = flint_options.name,
         .linkage = .dynamic,
         .root_module = module,
         .use_llvm = true,

--- a/src/lib/build/MatrixStep.zig
+++ b/src/lib/build/MatrixStep.zig
@@ -1,0 +1,131 @@
+//! This allows building various permutations of your game for testing purposes. The results will be placed in the
+//! ./zig-out/builds directory of your project. The buildGame function is called on each permutation, that function is
+//! where you place all the build logic your game needs.
+const std = @import("std");
+const integration = @import("integration.zig");
+
+const PLATFORM = @import("builtin").os.tag;
+const PLATFORM_CPU = @import("builtin").target.cpu;
+const DEFAULT_TARGETS = [_]std.Target.Query{
+    .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+    .{ .cpu_arch = .aarch64, .os_tag = .macos },
+};
+const DEFAULT_OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
+const DEFAULT_INTERNAL_MODES = [_]bool{ true, false };
+
+// Types.
+const Step = std.Build.Step;
+const IntegrateOptions = integration.IntegrateOptions;
+const BuildMatrixStep = @This();
+
+/// The buildGame function called by the buildMatrix for each permutation of the matrix.
+pub const BuildGameFnType = *const fn (b: *std.Build, flint_options: IntegrateOptions) BuildResult;
+
+/// The result expected back from the buildGame function.
+pub const BuildResult = struct {
+    exe: ?*std.Build.Step.Compile,
+    lib: *std.Build.Step.Compile,
+    assets_path: ?std.Build.LazyPath,
+};
+
+/// The options that can be passed to the build matrix. It contains a default set of targets, optimization modes and
+/// internal modes but you can pass your own sets for either of them instead.
+pub const Options = struct {
+    options: IntegrateOptions,
+    buildGame: BuildGameFnType,
+    targets: []const std.Target.Query = &DEFAULT_TARGETS,
+    optimize_modes: []const std.builtin.OptimizeMode = &DEFAULT_OPTIMIZE_MODES,
+    internal_modes: []const bool = &DEFAULT_INTERNAL_MODES,
+};
+
+step: Step,
+options: Options,
+
+pub fn create(b: *std.Build, step_options: Options) *BuildMatrixStep {
+    const matrix = b.allocator.create(BuildMatrixStep) catch @panic("OOM");
+    matrix.* = .{
+        .step = .init(.{
+            .id = .custom,
+            .name = "build_matrix",
+            .owner = b,
+            .makeFn = make,
+        }),
+        .options = step_options,
+    };
+
+    const options = step_options.options;
+    var step = &matrix.step;
+
+    for (step_options.targets) |target_query| {
+        // Skip MacOS when on a different platform without specifying the sysroot which is required for SDL.
+        if (b.sysroot == null and target_query.os_tag == .macos and target_query.os_tag != PLATFORM) {
+            continue;
+        }
+
+        // If we are building for the same OS and CPU as the build is running on we consider it a native build.
+        const use_native_query = (target_query.os_tag == PLATFORM and target_query.cpu_arch == PLATFORM_CPU.arch);
+
+        const target = b.resolveTargetQuery(target_query);
+        for (step_options.optimize_modes) |optimize| {
+            for (step_options.internal_modes) |internal| {
+                const dest_path: []const u8 = b.fmt("builds/{s}-{s}-{s}-{s}-{s}", .{
+                    options.name,
+                    @tagName(target_query.os_tag.?),
+                    @tagName(target_query.cpu_arch.?),
+                    @tagName(optimize),
+                    if (internal) "internal" else "release",
+                });
+                const dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .{ .override = .{ .custom = dest_path } };
+                const result = step_options.buildGame(b, .{
+                    .dependency = options.dependency,
+                    // Workaround for the fact that zig build system considers any values in the target query to be
+                    // non-native even if they match the build machine. Without this the SDL build.zig will complain
+                    // about missing --sysroot even when we are running on MacOS and don't actually need to specify it.
+                    // By passing a the default target in this case the target will be considered native.
+                    .target = if (use_native_query) options.target else target,
+                    .optimize = optimize,
+                    .build_options = b.addOptions(),
+                    .name = options.name,
+                    .internal = internal,
+                    .skip_run_step = true,
+                    .install_step = step,
+                    .dest_dir = dest_dir,
+                });
+
+                // Install executable.
+                if (result.exe) |exe| {
+                    step.dependOn(&b.addInstallArtifact(exe, .{ .dest_dir = dest_dir }).step);
+                }
+
+                // Install game library.
+                step.dependOn(&b.addInstallArtifact(result.lib, .{ .dest_dir = dest_dir }).step);
+
+                // Install game assets.
+                if (result.assets_path) |assets_path| {
+                    step.dependOn(&b.addInstallDirectory(.{
+                        .source_dir = assets_path,
+                        .install_dir = .{ .custom = dest_path },
+                        .install_subdir = "assets",
+                    }).step);
+                }
+            }
+        }
+    }
+
+    return matrix;
+}
+
+fn make(step: *Step, options: Step.MakeOptions) !void {
+    _ = options;
+
+    const b = step.owner;
+    const matrix: *BuildMatrixStep = @fieldParentPtr("step", step);
+
+    for (matrix.options.targets) |target_query| {
+        // Skip MacOS when on a different platform without specifying the sysroot which is required for SDL.
+        if (b.sysroot == null and target_query.os_tag == .macos and target_query.os_tag != PLATFORM) {
+            std.log.info("MacOS skipped since --sysroot was not specified, the Apple SDKs are required for cross compiling to this target.", .{});
+        }
+    }
+}

--- a/src/lib/build/integration.zig
+++ b/src/lib/build/integration.zig
@@ -1,0 +1,23 @@
+//! These structs are used for the build integration.
+const std = @import("std");
+
+/// This struct defines the options that need to be passed to the `integrate` function.
+pub const IntegrateOptions = struct {
+    dependency: *std.Build.Dependency,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    build_options: *std.Build.Step.Options,
+    internal: bool = true,
+    name: []const u8 = "game",
+    lib_only: bool = false,
+    skip_run_step: bool = false,
+    install_step: *std.Build.Step,
+    dest_dir: std.Build.Step.InstallArtifact.Options.Dir = .default,
+};
+
+/// This struct contains the results of the `integrate` function.
+pub const IntegrateResult = struct {
+    flint_mod: *std.Build.Module,
+    exe: ?*std.Build.Step.Compile,
+    build_options_mod: *std.Build.Module,
+};

--- a/src/lib/docs.zig
+++ b/src/lib/docs.zig
@@ -1,61 +1,108 @@
 //! This is the "flint" module that is exposed by flint which contains various building blocks that
 //! can be imported into your game to serve as a basis for your game engine.
 //!
-//! ## Build integration
+//! ## Quick start
+//! The easiest way to get started is to use the new project generator:
+//! ```
+//! git clone https://github.com/zoeesilcock/flint.git && cd flint
+//!
+//! zig build new -- ../my_new_project
+//!
+//! cd ../my_new_project && zig build run
+//! ```
+//!
+//! ## Manual build integration
 //! * Add flint as a dependency in your `build.zig.zon` file by running:
 //! ```
 //! zig fetch --save git+https://github.com/zoeesilcock/flint.git#v0.10.0
 //! ```
-//! * Add the following to your `build.zig` file:
+//! * Example `build.zig` file:
 //! ```
+//! const std = @import("std");
 //! const flint = @import("flint");
 //!
-//! const target = b.standardTargetOptions(.{});
-//! const optimize = b.standardOptimizeOption(.{});
+//! const TARGETS = [_]std.Target.Query{
+//!     .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
+//!     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
+//!     // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+//! };
+//! const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
+//! const INTERNAL_MODES = [_]bool{ true, false };
 //!
-//! // Integrate Flint.
-//! const result = flint.integrate(b, .{
-//!     .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
-//!     .target = target,
-//!     .optimize = optimize,
-//!     .build_options = b.addOptions(),
-//!     .name = b.option([]const u8, "name", "name of the shared library") orelse "your_lib_name",
-//!     .internal = b.option(bool, "internal", "include debug interface") orelse true,
-//!     .lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false,
-//! });
+//! pub fn build(b: *std.Build) void {
+//!     const target = b.standardTargetOptions(.{});
+//!     const optimize = b.standardOptimizeOption(.{});
+//!     const name = b.option([]const u8, "name", "name of the game (used for exe and lib)") orelse "template";
+//!     const internal = b.option(bool, "internal", "include debug interface") orelse true;
+//!     const lib_only = b.option(bool, "lib_only", "only build the shared library") orelse false;
 //!
-//! // Game library.
-//! const module = b.createModule(.{
-//!     .root_source_file = b.path("src/root.zig"),
-//!     .target = target,
-//!     .optimize = optimize,
-//! });
-//! module.addImport("build_options", result.build_options_mod);
-//! module.addImport("flint", result.flint_mod);
+//!     // Build game.
+//!     const flint_options: flint.IntegrateOptions = .{
+//!         .dependency = b.dependency("flint", .{ .target = target, .optimize = optimize }),
+//!         .target = target,
+//!         .optimize = optimize,
+//!         .build_options = b.addOptions(),
+//!         .name = name,
+//!         .internal = internal,
+//!         .lib_only = lib_only,
+//!         .install_step = b.getInstallStep(),
+//!         .dest_dir = .default,
+//!     };
+//!     const result = buildGame(b, flint_options);
 //!
-//! // Build the game as a dynamic library.
-//! const lib = b.addLibrary(.{
-//!     .name = "your_lib_name",
-//!     .linkage = .dynamic,
-//!     .root_module = module,
-//! });
-//! b.getInstallStep().dependOn(&b.addInstallArtifact(lib, .{}).step);
+//!     // Build all variations.
+//!     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
+//!     flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
 //!
-//! if (result.exe) |exe| {
-//!     b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{}).step);
+//!     // Install executable.
+//!     if (result.exe) |exe| {
+//!         b.getInstallStep().dependOn(&b.addInstallArtifact(exe, .{}).step);
+//!     }
+//!
+//!     // Install library.
+//!     b.getInstallStep().dependOn(&b.addInstallArtifact(result.lib, .{}).step);
+//!
+//!     // Check library.
+//!     const lib_check = b.addLibrary(.{
+//!         .name = name,
+//!         .linkage = .dynamic,
+//!         .root_module = result.lib.root_module,
+//!     });
+//!     const check = b.step("check", "Check if it compiles");
+//!     check.dependOn(&lib_check.step);
+//!
+//!     // Tests.
+//!     const test_step = b.step("test", "Run unit tests");
+//!     const lib_tests = b.addTest(.{ .root_module = result.lib.root_module });
+//!     const run_lib_tests = b.addRunArtifact(lib_tests);
+//!     test_step.dependOn(&run_lib_tests.step);
 //! }
-//! ```
-//! * The `build_options` field accepts a `*std.Build.Step.Options`. You can add your own
-//!   custom options to it before passing it to `integrate`. Flint will add its required
-//!   options (`internal` and `name`) and create the module for you:
-//! ```
-//! const build_options = b.addOptions();
-//! build_options.addOption(bool, "my_custom_flag", true);
 //!
-//! const result = flint.integrate(b, .{
-//!     // ...
-//!     .build_options = build_options,
-//! });
+//! fn buildGame(
+//!     b: *std.Build,
+//!     flint_options: flint.IntegrateOptions,
+//! ) flint.BuildResult {
+//!     // Integrate Flint.
+//!     const result = flint.integrate(b, flint_options);
+//!
+//!     // Game library.
+//!     const module = b.createModule(.{
+//!         .root_source_file = b.path("src/root.zig"),
+//!         .target = flint_options.target,
+//!         .optimize = flint_options.optimize,
+//!     });
+//!     module.addImport("build_options", result.build_options_mod);
+//!     module.addImport("flint", result.flint_mod);
+//!
+//!     const lib = b.addLibrary(.{
+//!         .name = flint_options.name,
+//!         .linkage = .dynamic,
+//!         .root_module = module,
+//!         .use_llvm = true,
+//!     });
+//!
+//!     return .{ .exe = result.exe, .lib = lib, .assets_path = b.path("assets") };
+//! }
 //! ```
 //!
 //! * The `internal` option decides if things like inspectors, editors, debug visualizations,
@@ -65,7 +112,7 @@
 //! const INTERNAL: bool = @import("build_options").internal;
 //! ```
 //!
-//! * See `src/examples/template/build.zig` for a complete example.
+//! * See `src/examples/template` for a complete example.
 //!
 //! ## Game library
 //! Flint expects you to create a library which exposes specific functions that will get called at various points in

--- a/src/lib/docs.zig
+++ b/src/lib/docs.zig
@@ -24,7 +24,7 @@
 //! const TARGETS = [_]std.Target.Query{
 //!     .{ .cpu_arch = .x86_64, .os_tag = .windows, .abi = .gnu },
 //!     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu },
-//!     // .{ .cpu_arch = .aarch64, .os_tag = .macos },
+//!     .{ .cpu_arch = .aarch64, .os_tag = .macos },
 //! };
 //! const OPTIMIZE_MODES = [_]std.builtin.OptimizeMode{ .Debug, .ReleaseFast };
 //! const INTERNAL_MODES = [_]bool{ true, false };

--- a/src/lib/docs.zig
+++ b/src/lib/docs.zig
@@ -52,7 +52,8 @@
 //!
 //!     // Build all variations.
 //!     const build_all_step = b.step("all", "Builds all permutations of the game for testing purposes.");
-//!     flint.buildMatrix(b, build_all_step, flint_options, &buildGame, &TARGETS, &OPTIMIZE_MODES, &INTERNAL_MODES);
+//!     const build_matrix = flint.BuildMatrixStep.create(b, .{ .options = flint_options, .buildGame = &buildGame });
+//!     build_all_step.dependOn(&build_matrix.step);
 //!
 //!     // Install executable.
 //!     if (result.exe) |exe| {
@@ -127,3 +128,6 @@ pub const imgui = @import("imgui.zig");
 pub const internal = @import("internal.zig");
 
 pub const GameLib = @import("GameLib.zig");
+
+pub const integration = @import("build/integration.zig");
+pub const BuildMatrixStep = @import("build/MatrixStep.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -186,7 +186,7 @@ pub fn main(init: std.process.Init) !void {
 
             if (code_changed) {
                 std.log.info("Code changed, rebuilding game library...", .{});
-                _ = try std.process.spawn(init.io, .{ .argv = &.{ "zig", "build", "-Dlib_only", "-fincremental" } });
+                _ = try std.process.spawn(init.io, .{ .argv = &.{ "zig", "build", "-Dlib_only" } });
             }
 
             if (dll_changed or assets_changed) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -186,7 +186,7 @@ pub fn main(init: std.process.Init) !void {
 
             if (code_changed) {
                 std.log.info("Code changed, rebuilding game library...", .{});
-                _ = try std.process.spawn(init.io, .{ .argv = &.{ "zig", "build", "-Dlib_only" } });
+                _ = try std.process.spawn(init.io, .{ .argv = &.{ "zig", "build", "-Dlib_only", "-fincremental" } });
             }
 
             if (dll_changed or assets_changed) {


### PR DESCRIPTION
Added the ability to define a build matrix that allows automating building of all permutations of your game that you want. It supports three dimensions: target platform, optimize mode, and internal/release builds. This gives a fast way to catch any compilation errors that aren't happening on the native target or in release mode for example. This also includes basic packaging by copying assets, executable, and libraries into the same directory which provides an easy way to test all permutations of the game.